### PR TITLE
Make focus hint default

### DIFF
--- a/messages.js
+++ b/messages.js
@@ -48,6 +48,10 @@ var prefs_appearance_window_gaps_title = _("Gaps");
 var prefs_appearance_window_gaps_size_label = _("Gaps Size");
 var prefs_appearance_window_gaps_increment_label = _("Gaps Size Multiplier");
 var prefs_appearance_window_gaps_hidden_single_label = _("Gaps Hidden when Single");
+
+var prefs_appearance_borders_title = _("Borders");
+var prefs_appearance_focus_borders_label = _("Show Focus Hint Border");
+
 var prefs_appearance_color = _("Color");
 var prefs_appearance_color_border_size_label = _("Border Size");
 var prefs_appearance_color_border_color_label = _("Border Color");

--- a/po/es.po
+++ b/po/es.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Forge\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-18 21:56-0400\n"
+"POT-Creation-Date: 2023-05-28 19:28+0300\n"
 "PO-Revision-Date: 2021-09-18 16:25-0400\n"
 "Last-Translator: Jose Maranan <jmmaranan@gmail.com>\n"
 "Language-Team: \n"
@@ -64,228 +64,236 @@ msgstr ""
 msgid "Gaps Hidden when Single"
 msgstr ""
 
-#: messages.js:51
-msgid "Color"
-msgstr ""
-
 #: messages.js:52
-msgid "Border Size"
+msgid "Borders"
 msgstr ""
 
 #: messages.js:53
-msgid "Border Color"
-msgstr ""
-
-#: messages.js:54
-msgid "Palette Mode"
+msgid "Show Focus Hint Border"
 msgstr ""
 
 #: messages.js:55
-msgid "Editor Mode"
+msgid "Color"
 msgstr ""
 
 #: messages.js:56
-msgid "Apply Changes"
+msgid "Border Size"
 msgstr ""
 
-#: messages.js:57 messages.js:58
-msgid "Reset"
+#: messages.js:57
+msgid "Border Color"
+msgstr ""
+
+#: messages.js:58
+msgid "Palette Mode"
 msgstr ""
 
 #: messages.js:59
-msgid "Layout"
+msgid "Editor Mode"
 msgstr ""
 
 #: messages.js:60
-msgid "Default Drag-and-Drop Center Layout"
+msgid "Apply Changes"
 msgstr ""
 
-#: messages.js:61
-msgid "Tabbed"
+#: messages.js:61 messages.js:62
+msgid "Reset"
 msgstr ""
 
-#: messages.js:62
-msgid "Stacked"
+#: messages.js:63
+msgid "Layout"
 msgstr ""
 
 #: messages.js:64
-msgid "Workspace"
+msgid "Default Drag-and-Drop Center Layout"
 msgstr ""
 
 #: messages.js:65
-msgid "Update Workspace Settings"
+msgid "Tabbed"
 msgstr ""
 
 #: messages.js:66
-msgid "Skip Workspace Tiling"
+msgid "Stacked"
 msgstr ""
 
 #: messages.js:68
+msgid "Workspace"
+msgstr ""
+
+#: messages.js:69
+msgid "Update Workspace Settings"
+msgstr ""
+
+#: messages.js:70
+msgid "Skip Workspace Tiling"
+msgstr ""
+
+#: messages.js:72
 msgid ""
 "Provide workspace indices to skip. E.g. 0,1. Empty text to disable. Enter to "
 "accept"
 msgstr ""
 
-#: messages.js:71
+#: messages.js:75
 msgid "Window Shortcuts"
 msgstr ""
 
-#: messages.js:72
+#: messages.js:76
 msgid "Workspace Shortcuts"
 msgstr ""
 
-#: messages.js:73
+#: messages.js:77
 msgid "Container Shortcuts"
 msgstr ""
 
-#: messages.js:74
+#: messages.js:78
 msgid "Focus Shortcuts"
 msgstr ""
 
-#: messages.js:75
+#: messages.js:79
 msgid "Other Shortcuts"
 msgstr ""
 
-#: messages.js:76
+#: messages.js:80
 msgid "Modifier Keys"
 msgstr ""
 
-#: messages.js:77
+#: messages.js:81
 msgid "Drag-Drop Tiling Modifier Key Options"
 msgstr ""
 
-#: messages.js:79
+#: messages.js:83
 msgid "Change the modifier for <b>tiling</b> windows via mouse/drag-drop"
 msgstr ""
 
-#: messages.js:82
+#: messages.js:86
 msgid "Select <i>None</i> to <u>always tile immediately</u> by default"
 msgstr ""
 
-#: messages.js:84
+#: messages.js:88
 msgid "Tile Modifier"
 msgstr ""
 
-#: messages.js:85
+#: messages.js:89
 msgid "Ctrl"
 msgstr ""
 
-#: messages.js:86
+#: messages.js:90
 msgid "Super"
 msgstr ""
 
-#: messages.js:87
+#: messages.js:91
 msgid "Alt"
 msgstr ""
 
-#: messages.js:88
+#: messages.js:92
 msgid "None"
 msgstr ""
 
-#: messages.js:90
+#: messages.js:94
 msgid "Logger Level"
 msgstr ""
 
-#: messages.js:93
+#: messages.js:97
 msgid ""
 "CAUTION: These settings when enabled are buggy or can cause the shell to "
 "crash"
 msgstr ""
 
-#: messages.js:96
+#: messages.js:100
 msgid ""
 "Stacked Tiling Mode (Stack windows on top of each other while still being "
 "tiled)"
 msgstr ""
 
-#: messages.js:98
+#: messages.js:102
 msgid "Tabbed Tiling Mode (Group tiled windows as tabs)"
 msgstr ""
 
-#: messages.js:100
+#: messages.js:104
 msgid "Float Mode Always On Top (Floating windows always above tiling windows)"
 msgstr ""
 
-#: messages.js:102
+#: messages.js:106
 msgid "Auto Split (Quarter Tiling)"
 msgstr ""
 
-#: messages.js:103
+#: messages.js:107
 msgid "Preview Hint Toggle"
 msgstr ""
 
-#: messages.js:105
+#: messages.js:109
 msgid "Update Keybindings"
 msgstr ""
 
-#: messages.js:106
+#: messages.js:110
 msgid "Syntax"
 msgstr ""
 
-#: messages.js:107
+#: messages.js:111
 msgid "Legend"
 msgstr ""
 
-#: messages.js:108
+#: messages.js:112
 msgid "Windows key"
 msgstr ""
 
-#: messages.js:109
+#: messages.js:113
 msgid "Control key"
 msgstr ""
 
-#: messages.js:111
+#: messages.js:115
 msgid "Delete text to unset. Press Return key to accept. Focus out to ignore."
 msgstr ""
 
-#: messages.js:113
+#: messages.js:117
 msgid "Resets"
 msgstr ""
 
-#: messages.js:114
+#: messages.js:118
 msgid "to previous value when invalid"
 msgstr ""
 
-#: messages.js:115
+#: messages.js:119
 msgid "Action"
 msgstr ""
 
-#: messages.js:116
+#: messages.js:120
 msgid "Shortcut"
 msgstr ""
 
-#: messages.js:117
+#: messages.js:121
 msgid "Notes"
 msgstr ""
 
-#: messages.js:119
+#: messages.js:123
 msgid "Forge Panel Settings"
 msgstr ""
 
-#: messages.js:120
+#: messages.js:124
 msgid "Tile Mode"
 msgstr ""
 
-#: messages.js:121
+#: messages.js:125
 msgid "Open Preferences"
 msgstr ""
 
-#: messages.js:126
+#: messages.js:130
 msgid "Tiled Focus Hint and Preview"
 msgstr ""
 
-#: messages.js:128
+#: messages.js:132
 msgid "Floated Focus Hint"
 msgstr ""
 
-#: messages.js:130
+#: messages.js:134
 msgid "Split Direction Hint"
 msgstr ""
 
-#: messages.js:132
+#: messages.js:136
 msgid "Stacked Focus Hint and Preview"
 msgstr ""
 
-#: messages.js:134
+#: messages.js:138
 msgid "Tabbed Focus Hint and Preview"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Forge\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-18 21:56-0400\n"
+"POT-Creation-Date: 2023-05-28 19:28+0300\n"
 "PO-Revision-Date: 2023-02-28 17:16-0500\n"
 "Last-Translator: William Roy <wroy@proton.me>\n"
 "Language-Team: French - Canada <wroy@proton.me>\n"
@@ -71,63 +71,73 @@ msgstr "Taille des marges"
 msgid "Gaps Hidden when Single"
 msgstr "Marges masquées lorsqu'il y a une seule fenêtre"
 
-#: messages.js:51
-msgid "Color"
-msgstr "Couleur"
-
 #: messages.js:52
-msgid "Border Size"
+#, fuzzy
+msgid "Borders"
 msgstr "Taille de la bordure"
 
 #: messages.js:53
+#, fuzzy
+msgid "Show Focus Hint Border"
+msgstr "Indice de focus flottant"
+
+#: messages.js:55
+msgid "Color"
+msgstr "Couleur"
+
+#: messages.js:56
+msgid "Border Size"
+msgstr "Taille de la bordure"
+
+#: messages.js:57
 msgid "Border Color"
 msgstr "Couleur de la bordure"
 
-#: messages.js:54
+#: messages.js:58
 msgid "Palette Mode"
 msgstr "Mode Palette"
 
-#: messages.js:55
+#: messages.js:59
 msgid "Editor Mode"
 msgstr "Mode éditeur"
 
-#: messages.js:56
+#: messages.js:60
 msgid "Apply Changes"
 msgstr "Appliquer les changements"
 
-#: messages.js:57 messages.js:58
+#: messages.js:61 messages.js:62
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: messages.js:59
+#: messages.js:63
 msgid "Layout"
 msgstr "Disposition"
 
-#: messages.js:60
+#: messages.js:64
 msgid "Default Drag-and-Drop Center Layout"
 msgstr "Disposition centrale par défaut du glisser-déposer"
 
-#: messages.js:61
+#: messages.js:65
 msgid "Tabbed"
 msgstr "Onglets"
 
-#: messages.js:62
+#: messages.js:66
 msgid "Stacked"
 msgstr "Empilés"
 
-#: messages.js:64
+#: messages.js:68
 msgid "Workspace"
 msgstr "Espace de travail"
 
-#: messages.js:65
+#: messages.js:69
 msgid "Update Workspace Settings"
 msgstr "Mettre à jour les paramètres de l'espace de travail"
 
-#: messages.js:66
+#: messages.js:70
 msgid "Skip Workspace Tiling"
 msgstr "Désactiver la disposition en mosaïque de l'espace de travail"
 
-#: messages.js:68
+#: messages.js:72
 msgid ""
 "Provide workspace indices to skip. E.g. 0,1. Empty text to disable. Enter to "
 "accept"
@@ -135,71 +145,71 @@ msgstr ""
 "Indiquez les indices des espaces de travail à ignorer. Ex: 0,1. Laissez vide "
 "pour désactiver. Appuyez sur Entrée pour valider."
 
-#: messages.js:71
+#: messages.js:75
 msgid "Window Shortcuts"
 msgstr "Raccourcis de la fenêtre"
 
-#: messages.js:72
+#: messages.js:76
 msgid "Workspace Shortcuts"
 msgstr "Raccourcis de l'espace de travail"
 
-#: messages.js:73
+#: messages.js:77
 msgid "Container Shortcuts"
 msgstr "Raccourcis pour les conteneurs"
 
-#: messages.js:74
+#: messages.js:78
 msgid "Focus Shortcuts"
 msgstr "Raccourcis de focus"
 
-#: messages.js:75
+#: messages.js:79
 msgid "Other Shortcuts"
 msgstr "Autres raccourcis"
 
-#: messages.js:76
+#: messages.js:80
 msgid "Modifier Keys"
 msgstr "Touches modificateurs"
 
-#: messages.js:77
+#: messages.js:81
 msgid "Drag-Drop Tiling Modifier Key Options"
 msgstr "Options de touche modificateur pour le glisser-déposer en mosaïque"
 
-#: messages.js:79
+#: messages.js:83
 msgid "Change the modifier for <b>tiling</b> windows via mouse/drag-drop"
 msgstr ""
 "Modifier la touche de modification pour les fenêtres en <b>mosaïque</b> via "
 "la souris ou le glisser-déposer"
 
-#: messages.js:82
+#: messages.js:86
 msgid "Select <i>None</i> to <u>always tile immediately</u> by default"
 msgstr ""
 "Sélectionnez <i>Aucun</i> pour <u>toujours afficher en mosaïque "
 "immédiatement</u> par défaut"
 
-#: messages.js:84
+#: messages.js:88
 msgid "Tile Modifier"
 msgstr "Touche modificateur pour la mosaïque"
 
-#: messages.js:85
+#: messages.js:89
 msgid "Ctrl"
 msgstr "Ctrl"
 
-#: messages.js:86
+#: messages.js:90
 msgid "Super"
 msgstr "Super"
 
-#: messages.js:87
+#: messages.js:91
 msgid "Alt"
 msgstr "Alt"
 
-#: messages.js:88
+#: messages.js:92
 msgid "None"
 msgstr "Aucune"
 
-#: messages.js:90
+#: messages.js:94
 msgid "Logger Level"
 msgstr "Niveau de journalisation"
 
-#: messages.js:93
+#: messages.js:97
 msgid ""
 "CAUTION: These settings when enabled are buggy or can cause the shell to "
 "crash"
@@ -207,7 +217,7 @@ msgstr ""
 "ATTENTION : Ces paramètres, lorsqu'ils sont activés, sont bogués ou peuvent "
 "causer un plantage de l'environnement de bureau"
 
-#: messages.js:96
+#: messages.js:100
 msgid ""
 "Stacked Tiling Mode (Stack windows on top of each other while still being "
 "tiled)"
@@ -215,47 +225,47 @@ msgstr ""
 "Mode de mosaïque en pile (empile les fenêtres les unes sur les autres tout "
 "en étant toujours en mosaïque)"
 
-#: messages.js:98
+#: messages.js:102
 msgid "Tabbed Tiling Mode (Group tiled windows as tabs)"
 msgstr ""
 "Mode mosaïque avec onglets (Groupe les fenêtres en mosaïque en tant "
 "qu'onglets)"
 
-#: messages.js:100
+#: messages.js:104
 msgid "Float Mode Always On Top (Floating windows always above tiling windows)"
 msgstr ""
 "Mode flottant toujours au-dessus (Les fenêtres flottantes toujours au-dessus "
 "des fenêtres en mosaïque)"
 
-#: messages.js:102
+#: messages.js:106
 msgid "Auto Split (Quarter Tiling)"
 msgstr "Fractionnement automatique (Mosaïque en quart)"
 
-#: messages.js:103
+#: messages.js:107
 msgid "Preview Hint Toggle"
 msgstr "Basculer l'indice de prévisualisation"
 
-#: messages.js:105
+#: messages.js:109
 msgid "Update Keybindings"
 msgstr "Mettre à jour les raccourcis clavier"
 
-#: messages.js:106
+#: messages.js:110
 msgid "Syntax"
 msgstr "Syntaxe"
 
-#: messages.js:107
+#: messages.js:111
 msgid "Legend"
 msgstr "légende"
 
-#: messages.js:108
+#: messages.js:112
 msgid "Windows key"
 msgstr "Touche Windows"
 
-#: messages.js:109
+#: messages.js:113
 msgid "Control key"
 msgstr "Touche contrôle"
 
-#: messages.js:111
+#: messages.js:115
 msgid "Delete text to unset. Press Return key to accept. Focus out to ignore."
 msgstr ""
 "Supprimez le texte pour annuler. Appuyez sur la touche Entrée pour accepter. "
@@ -263,56 +273,56 @@ msgstr ""
 
 # Seems to go hand in hand with the next one.
 # e.g. Resets to previous value when invalid.
-#: messages.js:113
+#: messages.js:117
 msgid "Resets"
 msgstr "Remise"
 
-#: messages.js:114
+#: messages.js:118
 msgid "to previous value when invalid"
 msgstr "à la valeur précédente en cas d'invalidité"
 
-#: messages.js:115
+#: messages.js:119
 msgid "Action"
 msgstr "Action"
 
-#: messages.js:116
+#: messages.js:120
 msgid "Shortcut"
 msgstr "Raccourcis"
 
-#: messages.js:117
+#: messages.js:121
 msgid "Notes"
 msgstr "Notes"
 
 # I'm not sure about that. It translates a bit oddly. 
-#: messages.js:119
+#: messages.js:123
 msgid "Forge Panel Settings"
 msgstr "Paramètres du panneau de Forge"
 
-#: messages.js:120
+#: messages.js:124
 msgid "Tile Mode"
 msgstr "Mode mosaïque"
 
-#: messages.js:121
+#: messages.js:125
 msgid "Open Preferences"
 msgstr "Ouvrir les préférences"
 
-#: messages.js:126
+#: messages.js:130
 msgid "Tiled Focus Hint and Preview"
 msgstr "Indice de prévisualisation et aperçu de la mise au point en mosaïque"
 
-#: messages.js:128
+#: messages.js:132
 msgid "Floated Focus Hint"
 msgstr "Indice de focus flottant"
 
-#: messages.js:130
+#: messages.js:134
 msgid "Split Direction Hint"
 msgstr "Indicateur pour la direction du fractionnement"
 
-#: messages.js:132
+#: messages.js:136
 msgid "Stacked Focus Hint and Preview"
 msgstr "Indicateur de focus empilé et prévisualisation"
 
-#: messages.js:134
+#: messages.js:138
 msgid "Tabbed Focus Hint and Preview"
 msgstr "Indicateur de focus en onglets et prévisualisation"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Forge\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-18 21:56-0400\n"
+"POT-Creation-Date: 2023-05-28 19:28+0300\n"
 "PO-Revision-Date: 2021-12-29 19:04+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: \n"
@@ -67,63 +67,73 @@ msgstr "Ruimte tussen vensters"
 msgid "Gaps Hidden when Single"
 msgstr "Ruimtes verbergen bij één geopend venster"
 
-#: messages.js:51
-msgid "Color"
-msgstr "Kleur"
-
 #: messages.js:52
-msgid "Border Size"
+#, fuzzy
+msgid "Borders"
 msgstr "Randbreedte"
 
 #: messages.js:53
+#, fuzzy
+msgid "Show Focus Hint Border"
+msgstr "Focushint bij zwevende vensters"
+
+#: messages.js:55
+msgid "Color"
+msgstr "Kleur"
+
+#: messages.js:56
+msgid "Border Size"
+msgstr "Randbreedte"
+
+#: messages.js:57
 msgid "Border Color"
 msgstr "Randkleur"
 
-#: messages.js:54
+#: messages.js:58
 msgid "Palette Mode"
 msgstr "Paletmodus"
 
-#: messages.js:55
+#: messages.js:59
 msgid "Editor Mode"
 msgstr "Bewerkmodus"
 
-#: messages.js:56
+#: messages.js:60
 msgid "Apply Changes"
 msgstr "Wijzigingen toepassen"
 
-#: messages.js:57 messages.js:58
+#: messages.js:61 messages.js:62
 msgid "Reset"
 msgstr "Standaardwaarden"
 
-#: messages.js:59
+#: messages.js:63
 msgid "Layout"
 msgstr "Indeling"
 
-#: messages.js:60
+#: messages.js:64
 msgid "Default Drag-and-Drop Center Layout"
 msgstr "Standaardindeling: gecentreerd slepen-en-neerzetten"
 
-#: messages.js:61
+#: messages.js:65
 msgid "Tabbed"
 msgstr "Tabbladen"
 
-#: messages.js:62
+#: messages.js:66
 msgid "Stacked"
 msgstr "Gestapeld"
 
-#: messages.js:64
+#: messages.js:68
 msgid "Workspace"
 msgstr "Werkblad"
 
-#: messages.js:65
+#: messages.js:69
 msgid "Update Workspace Settings"
 msgstr "Werkbladvoorkeuren bijwerken"
 
-#: messages.js:66
+#: messages.js:70
 msgid "Skip Workspace Tiling"
 msgstr "Niet tegelen op werkblad"
 
-#: messages.js:68
+#: messages.js:72
 msgid ""
 "Provide workspace indices to skip. E.g. 0,1. Empty text to disable. Enter to "
 "accept"
@@ -131,69 +141,69 @@ msgstr ""
 "Geef op op welke werkbladen er niet dient te worden getegeld, bijv. 0,1. "
 "Laat leeg om uit te schakelen. Druk Enter om toe te passen."
 
-#: messages.js:71
+#: messages.js:75
 msgid "Window Shortcuts"
 msgstr "Venstersneltoetsen"
 
-#: messages.js:72
+#: messages.js:76
 msgid "Workspace Shortcuts"
 msgstr "Werkbladsneltoetsen"
 
-#: messages.js:73
+#: messages.js:77
 msgid "Container Shortcuts"
 msgstr "Containersneltoetsen"
 
-#: messages.js:74
+#: messages.js:78
 msgid "Focus Shortcuts"
 msgstr "Focussneltoetsen"
 
-#: messages.js:75
+#: messages.js:79
 msgid "Other Shortcuts"
 msgstr "Overige sneltoetsen"
 
-#: messages.js:76
+#: messages.js:80
 msgid "Modifier Keys"
 msgstr "Actietoetsen"
 
-#: messages.js:77
+#: messages.js:81
 msgid "Drag-Drop Tiling Modifier Key Options"
 msgstr "Opties omtrent actietoets voor tegelen middels slepen-en-neerzetten"
 
-#: messages.js:79
+#: messages.js:83
 msgid "Change the modifier for <b>tiling</b> windows via mouse/drag-drop"
 msgstr ""
 "Wijzig de actietoets voor het <b>tegelen</b> van vensters middels slepen-en-"
 "neerzetten"
 
-#: messages.js:82
+#: messages.js:86
 msgid "Select <i>None</i> to <u>always tile immediately</u> by default"
 msgstr "Kies <i>Geen</i> om <u>altijd direct te tegelen</u>"
 
-#: messages.js:84
+#: messages.js:88
 msgid "Tile Modifier"
 msgstr "Tegel-actietoets"
 
-#: messages.js:85
+#: messages.js:89
 msgid "Ctrl"
 msgstr "Ctrl"
 
-#: messages.js:86
+#: messages.js:90
 msgid "Super"
 msgstr "Super"
 
-#: messages.js:87
+#: messages.js:91
 msgid "Alt"
 msgstr "Alt"
 
-#: messages.js:88
+#: messages.js:92
 msgid "None"
 msgstr "Geen"
 
-#: messages.js:90
+#: messages.js:94
 msgid "Logger Level"
 msgstr "Logniveau"
 
-#: messages.js:93
+#: messages.js:97
 msgid ""
 "CAUTION: These settings when enabled are buggy or can cause the shell to "
 "crash"
@@ -201,103 +211,103 @@ msgstr ""
 "LET OP: deze voorkeuren kunnen instabiliteit veroorzaken of zelfs de shell "
 "laten crashen!"
 
-#: messages.js:96
+#: messages.js:100
 msgid ""
 "Stacked Tiling Mode (Stack windows on top of each other while still being "
 "tiled)"
 msgstr "Gestapelde tegelmodus (stapel vensters in de tegelmodus)"
 
-#: messages.js:98
+#: messages.js:102
 msgid "Tabbed Tiling Mode (Group tiled windows as tabs)"
 msgstr "Tabblad-tegelmodus (groepeer getegelde vensters als tabbladen)"
 
-#: messages.js:100
+#: messages.js:104
 msgid "Float Mode Always On Top (Floating windows always above tiling windows)"
 msgstr ""
 
-#: messages.js:102
+#: messages.js:106
 msgid "Auto Split (Quarter Tiling)"
 msgstr ""
 
-#: messages.js:103
+#: messages.js:107
 msgid "Preview Hint Toggle"
 msgstr ""
 
-#: messages.js:105
+#: messages.js:109
 msgid "Update Keybindings"
 msgstr "Sneltoetsen bijwerken"
 
-#: messages.js:106
+#: messages.js:110
 msgid "Syntax"
 msgstr "Syntaxis"
 
-#: messages.js:107
+#: messages.js:111
 msgid "Legend"
 msgstr "Legenda"
 
-#: messages.js:108
+#: messages.js:112
 msgid "Windows key"
 msgstr "Windows-toets"
 
-#: messages.js:109
+#: messages.js:113
 msgid "Control key"
 msgstr "Ctrl-toets"
 
-#: messages.js:111
+#: messages.js:115
 msgid "Delete text to unset. Press Return key to accept. Focus out to ignore."
 msgstr ""
 "Wis de tekst om de toets wijzigen. Druk op enter om toe te passen. Klik "
 "erbuiten om te negeren."
 
-#: messages.js:113
+#: messages.js:117
 msgid "Resets"
 msgstr "Herstelt"
 
-#: messages.js:114
+#: messages.js:118
 msgid "to previous value when invalid"
 msgstr "de standaardwaarde indien ongeldig"
 
-#: messages.js:115
+#: messages.js:119
 msgid "Action"
 msgstr "Actie"
 
-#: messages.js:116
+#: messages.js:120
 msgid "Shortcut"
 msgstr "Sneltoets"
 
-#: messages.js:117
+#: messages.js:121
 msgid "Notes"
 msgstr "Opmerkingen"
 
-#: messages.js:119
+#: messages.js:123
 msgid "Forge Panel Settings"
 msgstr "Forge-paneelvoorkeuren"
 
-#: messages.js:120
+#: messages.js:124
 msgid "Tile Mode"
 msgstr "Tegelmodus"
 
-#: messages.js:121
+#: messages.js:125
 msgid "Open Preferences"
 msgstr "Voorkeuren openen"
 
-#: messages.js:126
+#: messages.js:130
 msgid "Tiled Focus Hint and Preview"
 msgstr "Hint bij tegelfocus en voorvertoning"
 
-#: messages.js:128
+#: messages.js:132
 msgid "Floated Focus Hint"
 msgstr "Focushint bij zwevende vensters"
 
-#: messages.js:130
+#: messages.js:134
 msgid "Split Direction Hint"
 msgstr "Hint bij veranderen van richting"
 
-#: messages.js:132
+#: messages.js:136
 msgid "Stacked Focus Hint and Preview"
 msgstr "Hint bij gestapelde tegelfocus en voorvertoning"
 
-#: messages.js:134
+#: messages.js:138
 msgid "Tabbed Focus Hint and Preview"
 msgstr "Hint bij tabblad-tegelfocus en voorvertoning"
 

--- a/po/pt-br.po
+++ b/po/pt-br.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Forge\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-18 21:56-0400\n"
+"POT-Creation-Date: 2023-05-28 19:28+0300\n"
 "PO-Revision-Date: 2021-09-18 16:25-0400\n"
 "Last-Translator: Juarez Rudsatz <juarezr@gmail.com>\n"
 "Language-Team: \n"
@@ -65,63 +65,73 @@ msgstr "Tamanho do Espaçamento"
 msgid "Gaps Hidden when Single"
 msgstr "Espaçamento Omitido quando Sozinho"
 
-#: messages.js:51
-msgid "Color"
-msgstr "Cor"
-
 #: messages.js:52
-msgid "Border Size"
+#, fuzzy
+msgid "Borders"
 msgstr "Tamanho de Borda"
 
 #: messages.js:53
+#, fuzzy
+msgid "Show Focus Hint Border"
+msgstr "Sinalizador de Foco Flutuante"
+
+#: messages.js:55
+msgid "Color"
+msgstr "Cor"
+
+#: messages.js:56
+msgid "Border Size"
+msgstr "Tamanho de Borda"
+
+#: messages.js:57
 msgid "Border Color"
 msgstr "Cor da Borda"
 
-#: messages.js:54
+#: messages.js:58
 msgid "Palette Mode"
 msgstr "Modo de Paleta"
 
-#: messages.js:55
+#: messages.js:59
 msgid "Editor Mode"
 msgstr "Modo de Edição"
 
-#: messages.js:56
+#: messages.js:60
 msgid "Apply Changes"
 msgstr "Aplicar Mudanças"
 
-#: messages.js:57 messages.js:58
+#: messages.js:61 messages.js:62
 msgid "Reset"
 msgstr "Restaurar"
 
-#: messages.js:59
+#: messages.js:63
 msgid "Layout"
 msgstr "Arranjo"
 
-#: messages.js:60
+#: messages.js:64
 msgid "Default Drag-and-Drop Center Layout"
 msgstr "Arranjo de Arrastar/Soltar Padrão"
 
-#: messages.js:61
+#: messages.js:65
 msgid "Tabbed"
 msgstr "Em Abas"
 
-#: messages.js:62
+#: messages.js:66
 msgid "Stacked"
 msgstr "Empilhado"
 
-#: messages.js:64
+#: messages.js:68
 msgid "Workspace"
 msgstr "Área de Trabalho"
 
-#: messages.js:65
+#: messages.js:69
 msgid "Update Workspace Settings"
 msgstr "Atualizar Configurações de Área de Trabalho"
 
-#: messages.js:66
+#: messages.js:70
 msgid "Skip Workspace Tiling"
 msgstr "Ignorar Emparelhamento de Área de Trabalho"
 
-#: messages.js:68
+#: messages.js:72
 msgid ""
 "Provide workspace indices to skip. E.g. 0,1. Empty text to disable. Enter to "
 "accept"
@@ -129,70 +139,70 @@ msgstr ""
 "Informe índices para ignorar. Ex: 0,1. Texto em branco para desabilitar. "
 "Enter para aceitar"
 
-#: messages.js:71
+#: messages.js:75
 msgid "Window Shortcuts"
 msgstr "Atalhos de Janela"
 
-#: messages.js:72
+#: messages.js:76
 msgid "Workspace Shortcuts"
 msgstr "Atalhos de Área de Trabalho"
 
-#: messages.js:73
+#: messages.js:77
 msgid "Container Shortcuts"
 msgstr "Atalhos de Container"
 
-#: messages.js:74
+#: messages.js:78
 msgid "Focus Shortcuts"
 msgstr "Atalhos de Foco"
 
-#: messages.js:75
+#: messages.js:79
 msgid "Other Shortcuts"
 msgstr "Outros Atalhos"
 
-#: messages.js:76
+#: messages.js:80
 msgid "Modifier Keys"
 msgstr "Teclas Modificadoras"
 
-#: messages.js:77
+#: messages.js:81
 msgid "Drag-Drop Tiling Modifier Key Options"
 msgstr "Opções de Teclas Modificadoras de Arrastar/Soltar"
 
-#: messages.js:79
+#: messages.js:83
 msgid "Change the modifier for <b>tiling</b> windows via mouse/drag-drop"
 msgstr ""
 "Altere o modificador para janelas <b>emparelhadas</b> através do mouse e "
 "arrastar/soltar"
 
-#: messages.js:82
+#: messages.js:86
 msgid "Select <i>None</i> to <u>always tile immediately</u> by default"
 msgstr ""
 "Selecione <i>Nenhum</i> para <u>sempre emparelhar imediatamente<u> por padrão"
 
-#: messages.js:84
+#: messages.js:88
 msgid "Tile Modifier"
 msgstr "Modificador de Emparelhamento"
 
-#: messages.js:85
+#: messages.js:89
 msgid "Ctrl"
 msgstr "Ctrl"
 
-#: messages.js:86
+#: messages.js:90
 msgid "Super"
 msgstr "Super"
 
-#: messages.js:87
+#: messages.js:91
 msgid "Alt"
 msgstr "Alt"
 
-#: messages.js:88
+#: messages.js:92
 msgid "None"
 msgstr "Nenhum"
 
-#: messages.js:90
+#: messages.js:94
 msgid "Logger Level"
 msgstr "Nivel de Log"
 
-#: messages.js:93
+#: messages.js:97
 msgid ""
 "CAUTION: These settings when enabled are buggy or can cause the shell to "
 "crash"
@@ -200,7 +210,7 @@ msgstr ""
 "CUIDADO: Estas configurações, quando ativadas, são problemáticas ou podem "
 "causar a queda da interface"
 
-#: messages.js:96
+#: messages.js:100
 msgid ""
 "Stacked Tiling Mode (Stack windows on top of each other while still being "
 "tiled)"
@@ -208,99 +218,99 @@ msgstr ""
 "Modo de Emparelhamento Empilhado (Empilhar janelas um em cima da outra mesmo "
 "ainda sendo emparelhadas)"
 
-#: messages.js:98
+#: messages.js:102
 msgid "Tabbed Tiling Mode (Group tiled windows as tabs)"
 msgstr "Modo de Emparelhamento em Abas (Agrupar janelas emparelhadas em abas)"
 
-#: messages.js:100
+#: messages.js:104
 msgid "Float Mode Always On Top (Floating windows always above tiling windows)"
 msgstr ""
 "Modo Flutuante Sempre no Topo (Janelas flutuantes sempre acima de janelas "
 "emparelhadas)"
 
-#: messages.js:102
+#: messages.js:106
 msgid "Auto Split (Quarter Tiling)"
 msgstr "Divisão Automática (Metade)"
 
-#: messages.js:103
+#: messages.js:107
 msgid "Preview Hint Toggle"
 msgstr "Alternar Ver Dica"
 
-#: messages.js:105
+#: messages.js:109
 msgid "Update Keybindings"
 msgstr "Atualizar Atalhos"
 
-#: messages.js:106
+#: messages.js:110
 msgid "Syntax"
 msgstr "Sintaxe"
 
-#: messages.js:107
+#: messages.js:111
 msgid "Legend"
 msgstr "Legenda"
 
-#: messages.js:108
+#: messages.js:112
 msgid "Windows key"
 msgstr "tecla Windows"
 
-#: messages.js:109
+#: messages.js:113
 msgid "Control key"
 msgstr "tecla Control"
 
-#: messages.js:111
+#: messages.js:115
 msgid "Delete text to unset. Press Return key to accept. Focus out to ignore."
 msgstr ""
 "Apague o texto para desativar. Pressione a tecla Enter para aceitar. Mude o "
 "foco para ignorar."
 
-#: messages.js:113
+#: messages.js:117
 msgid "Resets"
 msgstr "Restaurar"
 
-#: messages.js:114
+#: messages.js:118
 msgid "to previous value when invalid"
 msgstr "para o valor anterior quando inválido"
 
-#: messages.js:115
+#: messages.js:119
 msgid "Action"
 msgstr "Ação"
 
-#: messages.js:116
+#: messages.js:120
 msgid "Shortcut"
 msgstr "Atalho"
 
-#: messages.js:117
+#: messages.js:121
 msgid "Notes"
 msgstr "Nota"
 
-#: messages.js:119
+#: messages.js:123
 msgid "Forge Panel Settings"
 msgstr "Painel de Configuração do Forge"
 
-#: messages.js:120
+#: messages.js:124
 msgid "Tile Mode"
 msgstr "Modo de Emparelhamento"
 
-#: messages.js:121
+#: messages.js:125
 msgid "Open Preferences"
 msgstr "Abrir Preferências"
 
-#: messages.js:126
+#: messages.js:130
 msgid "Tiled Focus Hint and Preview"
 msgstr "Sinalizador de Foco Emparelhado e Pré-Visualização"
 
-#: messages.js:128
+#: messages.js:132
 msgid "Floated Focus Hint"
 msgstr "Sinalizador de Foco Flutuante"
 
-#: messages.js:130
+#: messages.js:134
 msgid "Split Direction Hint"
 msgstr "Sinalizador de Separação de Direção"
 
-#: messages.js:132
+#: messages.js:136
 msgid "Stacked Focus Hint and Preview"
 msgstr "Sinalizador de Foco Empilhado e Pré-Visualização"
 
-#: messages.js:134
+#: messages.js:138
 msgid "Tabbed Focus Hint and Preview"
 msgstr "Sinalizador de Foco em Abas e Pré-Visualização"
 

--- a/prefs.js
+++ b/prefs.js
@@ -478,9 +478,13 @@ var AppearanceWindowSettingsPanel = GObject.registerClass(
     _init(prefsWidget) {
       super._init(prefsWidget, `Appearance Window Settings`);
       this.settings = prefsWidget.settings;
+      this.initGapsSection();
+      this.initBordersSection();
+    }
 
-      let appearanceWindowFrame = new FrameListBox();
+    initGapsSection() {
       // Gaps Section
+      let gapsWindowFrame = new FrameListBox();
       let gapHeader = createLabel(Msgs.prefs_appearance_window_gaps_title);
       this.append(gapHeader);
 
@@ -557,11 +561,38 @@ var AppearanceWindowSettingsPanel = GObject.registerClass(
       gapHiddenWhenSingleRow.add(gapHiddenWhenSingleLabel);
       gapHiddenWhenSingleRow.add(gapHiddenWhenSingleSwitch);
 
-      appearanceWindowFrame.add(gapSizeRow);
-      appearanceWindowFrame.add(gapSizeIncrementRow);
-      appearanceWindowFrame.add(gapHiddenWhenSingleRow);
+      gapsWindowFrame.add(gapSizeRow);
+      gapsWindowFrame.add(gapSizeIncrementRow);
+      gapsWindowFrame.add(gapHiddenWhenSingleRow);
 
-      this.append(appearanceWindowFrame);
+      this.append(gapsWindowFrame);
+    }
+
+    initBordersSection() {
+      // Borders Section
+      let bordersWindowFrame = new FrameListBox();
+      let bordersHeader = createLabel(Msgs.prefs_appearance_borders_title);
+
+      let showFocusBorderRow = new ListBoxRow();
+      let showFocusBorderLabel = createLabel(Msgs.prefs_appearance_focus_borders_label);
+      let showFocusBorderSwitch = new Gtk.Switch();
+      showFocusBorderSwitch.set_active(this.settings.get_boolean("focus-border-toggle"));
+      showFocusBorderSwitch.connect("state-set", (_, state) => {
+        this.settings.set_boolean("focus-border-toggle", state);
+      });
+      this.settings.connect("changed", (_, keyName) => {
+        if (keyName === "focus-border-toggle") {
+          showFocusBorderSwitch.set_active(
+            this.settings.get_boolean("focus-border-toggle")
+          );
+        }
+      });
+      showFocusBorderRow.add(showFocusBorderLabel);
+      showFocusBorderRow.add(showFocusBorderSwitch);
+      bordersWindowFrame.add(showFocusBorderRow);
+
+      this.append(bordersHeader);
+      this.append(bordersWindowFrame)
     }
   }
 );

--- a/schemas/org.gnome.shell.extensions.forge.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.forge.gschema.xml
@@ -3,7 +3,7 @@
     <schema id="org.gnome.shell.extensions.forge" path="/org/gnome/shell/extensions/forge/">
         <!-- Main Settings -->
         <key type="b" name="focus-border-toggle">
-            <default>false</default>
+            <default>true</default>
             <summary>Show window border on focused window</summary>
         </key>
 


### PR DESCRIPTION
Makes focus hint the default, as in https://github.com/forge-ext/forge/issues/168