### PR TITLE
Fix quick settings implementation on GNOME 43-44

### DIFF
--- a/indicator.js
+++ b/indicator.js
@@ -10,6 +10,7 @@ const QuickSettingsMenu = imports.ui.main.panel.statusArea.quickSettings;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Logger = Me.imports.logger;
+const Utils = Me.imports.utils;
 
 const iconName = "view-grid-symbolic";
 
@@ -29,7 +30,10 @@ const FeatureMenuToggle = GObject.registerClass(
   class FeatureMenuToggle extends QuickSettings.QuickMenuToggle {
     _init(settings, extWm) {
       const title = _("Tiling");
-      super._init({ title, iconName, toggleMode: true });
+      const initSettings = Utils.isGnome(44)
+        ? { title, iconName, toggleMode: true }
+        : { label: title, iconName, toggleMode: true };
+      super._init(initSettings);
 
       this._settings = settings;
       this._extWm = extWm;

--- a/indicator.js
+++ b/indicator.js
@@ -107,11 +107,13 @@ var FeatureIndicator = GObject.registerClass(
     _addItems(items) {
       QuickSettingsMenu._addItems(items);
 
-      for (const item of items) {
-        QuickSettingsMenu.menu._grid.set_child_below_sibling(
-          item,
-          QuickSettingsMenu._backgroundApps.quickSettingsItems[0]
-        );
+      if (QuickSettingsMenu._backgroundApps) {
+        for (const item of items) {
+          QuickSettingsMenu.menu._grid.set_child_below_sibling(
+            item,
+            QuickSettingsMenu._backgroundApps.quickSettingsItems[0]
+          );
+        }
       }
     }
   }

--- a/preferences/about.js
+++ b/preferences/about.js
@@ -9,6 +9,7 @@ const Me = ExtensionUtils.getCurrentExtension();
 
 const _ = imports.gettext.domain(Me.metadata.uuid).gettext;
 const { developers } = Me.imports.preferences.metadata;
+const gnomeVersion = imports.misc.config.PACKAGE_VERSION;
 
 // Application imports
 const Msgs = Me.imports.messages;
@@ -19,27 +20,27 @@ function makeAboutButton(parent) {
     tooltip_text: _("About"),
     valign: Gtk.Align.CENTER,
   });
-  button.connect('clicked', () => showAboutWindow(parent));
+  button.connect("clicked", () => showAboutWindow(parent));
   return button;
 }
 
 function showAboutWindow(parent) {
   const { version: v, description: comments } = Me.metadata;
-  const version = v.toString();
+  const version = `${gnomeVersion}-${v.toString()}`;
   const abt = new Adw.AboutWindow({
-    ...parent && { transient_for: parent },
-     // TODO: fetch these from github at build time
-     application_name: _("Forge"),
-     application_icon: "forge-logo-symbolic",
-     version,
-     copyright: `© 2021-${new Date().getFullYear()} jmmaranan`,
-     issue_url: "https://github.com/forge-ext/forge/issues/new",
-     license_type: Gtk.License.GPL_3_0,
-     website:  'https://github.com/forge-ext/forge',
-     developers,
-     comments,
-     designers: [],
-     translator_credits: _("translator-credits"),
+    ...(parent && { transient_for: parent }),
+    // TODO: fetch these from github at build time
+    application_name: _("Forge"),
+    application_icon: "forge-logo-symbolic",
+    version,
+    copyright: `© 2021-${new Date().getFullYear()} jmmaranan`,
+    issue_url: "https://github.com/forge-ext/forge/issues/new",
+    license_type: Gtk.License.GPL_3_0,
+    website: "https://github.com/forge-ext/forge",
+    developers,
+    comments,
+    designers: [],
+    translator_credits: _("translator-credits"),
   });
-  abt.present()
+  abt.present();
 }

--- a/utils.js
+++ b/utils.js
@@ -30,6 +30,8 @@ const St = imports.gi.St;
 // Gnome-shell imports
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
+const Config = imports.misc.config;
+const [major, minor] = Config.PACKAGE_VERSION.split(".").map((s) => Number(s));
 
 // App imports
 const Logger = Me.imports.logger;
@@ -390,4 +392,8 @@ function _disableDecorations() {
 
 function dpi() {
   return St.ThemeContext.get_for_stage(global.stage).scale_factor;
+}
+
+function isGnome(majorVersion) {
+  return major == majorVersion;
 }


### PR DESCRIPTION
Fixes #235 

Background: GNOME introduced quick settings in Gnome 43 and following their guide some features are not available in between 43 and 44: https://gjs.guide/extensions/topics/quick-settings.html

I added an issue in GJS Docs if they can put a warning for anyone who stumbles upon it in their examples and find that it is missing in GNOME 43.
https://gitlab.gnome.org/ewlsh/gjs-guide/-/issues/64