### PR TITLE
Feature: remember last cursor/pointer position

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,17 @@ test-shell:
 	env GNOME_SHELL_SLOWDOWN_FACTOR=2 \
 		MUTTER_DEBUG_DUMMY_MODE_SPECS=1500x1000 \
 	  MUTTER_DEBUG_DUMMY_MONITOR_SCALES=1 \
-		dbus-run-session -- gnome-shell --nested --wayland
+		dbus-run-session -- gnome-shell --nested --wayland --wayland-display=wayland-forge
+
+# Usage: 
+#   make test-shell-open &
+#   make test-shell-open CMD=gnome-calculator
+#   make test-shell-open CMD=gnome-terminal ARGS='--app-id app.x'
+#   make test-shell-open CMD=firefox ARGS='--safe-mode' ENVVARS='MOZ_DBUS_REMOTE=1 MOZ_ENABLE_WAYLAND=1'
+#
+test-shell-open: CMD=gnome-text-editor
+test-shell-open:
+	GDK_BACKEND=wayland WAYLAND_DISPLAY=wayland-forge $(ENVVARS) $(CMD) $(ARGS)
 
 format:
 	npm run format

--- a/preferences/settings.js
+++ b/preferences/settings.js
@@ -97,6 +97,19 @@ var SettingsPage = GObject.registerClass(
         ],
       });
 
+      this.add_group({
+        title: _("Behavior"),
+        children: [
+          new SwitchRow({
+            title: _("Move Pointer to the Focused Window"),
+            subtitle: _("Move the pointer when focusing or swapping via keyboard"),
+            experimental: true,
+            settings,
+            bind: "move-pointer-focus-enabled",
+          }),
+        ]
+      });
+
       if (!production) {
         this.add_group({
           title: _("Logger"),

--- a/tree.js
+++ b/tree.js
@@ -1563,7 +1563,23 @@ var Tree = GObject.registerClass(
     }
 
     debugTree() {
+      this.debugChildNodes(this);
+    }
+
+    debugChildNodes(node) {
       this.debugNode(this);
+      node.childNodes.forEach((child) => {
+        this.debugChildNodes(child);
+      });
+    }
+
+    debugParentNodes(node) {
+      if (node) {
+        if (node.parentNode) {
+          this.debugParentNodes(node.parentNode);
+        }
+        this.debugNode(node);
+      }
     }
 
     debugNode(node) {
@@ -1592,6 +1608,13 @@ var Tree = GObject.registerClass(
 
       if (node.rect) {
         attributes += `,rect:${node.rect.width}x${node.rect.height}+${node.rect.x}+${node.rect.y}`;
+        const pointerCoord = global.get_pointer();
+        const pointerInside = Utils.rectContainsPoint(node.rect, pointerCoord) ? 'yes' : 'no';
+        attributes += `,pointer:${pointerInside}`;
+      }
+
+      if (node.pointer) {
+        attributes += `,last_position:${node.pointer.x}+${node.pointer.y}`;
       }
 
       if (level !== 0) Logger.debug(`${spacing}|`);
@@ -1600,10 +1623,6 @@ var Tree = GObject.registerClass(
           node.index !== null ? node.index : "-"
         } @${attributes}`
       );
-
-      node.childNodes.forEach((child) => {
-        this.debugNode(child);
-      });
     }
 
     findParent(childNode, parentNodeType) {

--- a/tree.js
+++ b/tree.js
@@ -79,6 +79,7 @@ var Node = GObject.registerClass(
       this.tab = null;
       this.decoration = null;
       this.app = null;
+      this.pointer = null;
 
       if (this.isWindow()) {
         // When destroy() is called on Meta.Window, it might not be

--- a/window.js
+++ b/window.js
@@ -2186,13 +2186,24 @@ var WindowManager = GObject.registerClass(
         const metaWindow = nodeWindow.nodeValue;
         const metaRect = metaWindow.get_frame_rect();
         const pointerCoord = global.get_pointer();
-        return metaRect 
+        return metaRect
           // xdg-copy creates a 1x1 pixel window to capture mouse events.
           && metaRect.width > 8
           && metaRect.height > 8
           && !Utils.rectContainsPoint(metaRect, pointerCoord)
           && !metaWindow.minimized
-          && !Overview.visible;
+          && !Overview.visible
+          && !this.nodeParentHasFocus(nodeWindow, pointerCoord)
+          ;
+      }
+      return false;
+    }
+
+    nodeParentHasFocus(nodeWindow, pointerCoord) {
+      if (pointerCoord && nodeWindow && nodeWindow.parentNode) {
+        if (nodeWindow.parentNode.isCon() && nodeWindow.parentNode.rect) {
+          return Utils.rectContainsPoint(nodeWindow.parentNode.rect, pointerCoord);
+        }
       }
       return false;
     }
@@ -2208,7 +2219,7 @@ var WindowManager = GObject.registerClass(
         }
         return {
           x: metaRect.x + metaRect.width / 2,
-          y: metaRect.y + metaRect.height / 2,
+          y: metaRect.y + 8, // on: titlebar: near to app toolbars, menubar, tabs, etc...
         };
       }
       return null;

--- a/window.js
+++ b/window.js
@@ -513,6 +513,7 @@ var WindowManager = GObject.registerClass(
           focusNodeWindow.nodeValue.raise();
           this.updateTabbedFocus(focusNodeWindow);
           this.updateStackedFocus(focusNodeWindow);
+          this.updatePointerPosition(focusNodeWindow);
           this.renderTree("swap", true);
           break;
         case "Split":
@@ -672,6 +673,7 @@ var WindowManager = GObject.registerClass(
             );
             let lastActiveNodeWindow = this.tree.findNode(lastActiveWindow);
             this.tree.swapPairs(lastActiveNodeWindow, focusNodeWindow);
+            this.updatePointerPosition(focusNodeWindow);
             this.renderTree("swap-last-active");
           }
           break;

--- a/window.js
+++ b/window.js
@@ -2196,16 +2196,17 @@ var WindowManager = GObject.registerClass(
           && !Utils.rectContainsPoint(metaRect, pointerCoord)
           && !metaWindow.minimized
           && !Overview.visible
-          && !this.nodeParentHasFocus(nodeWindow, pointerCoord)
+          && !this.pointerIsOverParentDecoration(nodeWindow, pointerCoord)
           ;
       }
       return false;
     }
 
-    nodeParentHasFocus(nodeWindow, pointerCoord) {
+    pointerIsOverParentDecoration(nodeWindow, pointerCoord) {
       if (pointerCoord && nodeWindow && nodeWindow.parentNode) {
-        if (nodeWindow.parentNode.isCon() && nodeWindow.parentNode.rect) {
-          return Utils.rectContainsPoint(nodeWindow.parentNode.rect, pointerCoord);
+        let node = nodeWindow.parentNode;
+        if (node.isTabbed() || node.isStacked()) {
+          return Utils.rectContainsPoint(node.rect, pointerCoord);
         }
       }
       return false;

--- a/window.js
+++ b/window.js
@@ -1494,6 +1494,8 @@ var WindowManager = GObject.registerClass(
             .get_workspace()
             .activate_with_focus(metaWindow, global.display.get_current_time());
           this.moveCenter(metaWindow);
+        } else {
+          this.updatePointerPosition(metaWindow);          
         }
       }
     }

--- a/window.js
+++ b/window.js
@@ -488,12 +488,12 @@ var WindowManager = GObject.registerClass(
                   if (prev) prev.parentNode.lastTabFocus = prev.nodeValue;
                   this.renderTree("move-tabbed-queue");
                 }
+                this.updatePointerPosition(focusNodeWindow);
               }
             },
           });
           if (moved) {
             if (prev) prev.parentNode.lastTabFocus = prev.nodeValue;
-            this.updatePointerPosition(focusNodeWindow);
             this.renderTree("move-window");
           }
 


### PR DESCRIPTION
## Proposed behavior

- After a window receives focus, the extension:
  - Checks if the cursor already is inside the window.
  - Checks if it has the last cursor position inside the window.
  - If positive then it doesn't change the cursor position
  - Otherwise:
    - When it has the last cursor position then it moves the cursor to this position.
    - Otherwise, it moves the cursor to the center of that window.
- Add a setting in preferences to enable it.

## Advantages

Using the last position for positioning the cursor has the following advantages:

- It's a better guess of what would be the shortest path from the cursor position to the next click position.
- It considers users' intentions for cursor placement.

## Disavantages

- It could raise involuntary click incident rates as it puts often the cursor near the last clicked widget.
- Sometimes users prefer fixed positions.
- The center of the window is the shortest distance to all points inside the window, thus being better positioned for fast movement. 
  - However, mouse clicks tend to concentrate on some hot spots instead of being linearly distributed through the window.