### PR TITLE
Expose split-border-toggle as a configurable setting

### DIFF
--- a/preferences/settings.js
+++ b/preferences/settings.js
@@ -58,6 +58,12 @@ var SettingsPage = GObject.registerClass(
             settings,
             bind: "focus-border-toggle",
           }),
+          new SwitchRow({
+            title: _("Show Window Split Hint Border"),
+            subtitle: _("Show split direction border on focused window"),
+            settings,
+            bind: "split-border-toggle",
+          }),
           new DropDownRow({
             title: Msgs.prefs_appearance_layout_dnd_default_layout,
             settings,


### PR DESCRIPTION
When full-screen gaps are disabled, this creates an (IMO) ugly looking yellow border on the right-hand side:

![image](https://github.com/forge-ext/forge/assets/38560/079940fc-f26e-4b06-8b98-971e26225a14)

`split-border-toggle` is already a setting that is registered in the gschema.   It is always `true`, since there is not a way to change this setting.  

This change exposes split-border-toggle as a user-configurable setting.  It will allow users to remove the yellow split border on full-screen windows:

![image](https://github.com/forge-ext/forge/assets/38560/7ddf229f-d0b8-48bb-8cc9-9629d1951e30)