### PR TITLE
Fix: extensions review feedback

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -31,13 +31,9 @@ import { FeatureIndicator, FeatureMenuToggle } from "./lib/extension/indicator.j
 import { ExtensionThemeManager } from "./lib/extension/extension-theme-manager.js";
 
 export default class ForgeExtension extends Extension {
-  settings = this.getSettings();
-
-  kbdSettings = this.getSettings("org.gnome.shell.extensions.forge.keybindings");
-
-  sameSession = false;
-
   enable() {
+    this.settings = this.getSettings();
+    this.kbdSettings = this.getSettings("org.gnome.shell.extensions.forge.keybindings");
     Logger.init(this.settings);
     Logger.info("enable");
 
@@ -51,13 +47,6 @@ export default class ForgeExtension extends Extension {
 
     this.theme.patchCss();
     this.theme.reloadStylesheet();
-
-    if (this.sameSession) {
-      Logger.debug(`enable: still in same session`);
-      this.sameSession = false;
-      return;
-    }
-
     this.extWm.enable();
     this.keybindings.enable();
     Logger.info(`enable: finalized vars`);
@@ -65,13 +54,6 @@ export default class ForgeExtension extends Extension {
 
   disable() {
     Logger.info("disable");
-
-    if (Main.sessionMode.isLocked) {
-      this.sameSession = true;
-      Logger.debug(`disable: still in same session`);
-      return;
-    }
-
     this.extWm.disable();
     this.keybindings.disable();
     this.indicator?.quickSettingsItems.forEach((item) => item.destroy());
@@ -81,5 +63,7 @@ export default class ForgeExtension extends Extension {
     this.extWm = null;
     this.themeWm = null;
     this.configMgr = null;
+    this.settings = null;
+    this.kbdSettings = null;
   }
 }

--- a/lib/extension/utils.js
+++ b/lib/extension/utils.js
@@ -196,15 +196,15 @@ export function resolveDirection(directionString) {
   return null;
 }
 
-export function directionFrom(position, orientaton) {
+export function directionFrom(position, orientation) {
   if (position === POSITION.AFTER) {
-    if (orientaton === ORIENTATION_TYPES.HORIZONTAL) {
+    if (orientation === ORIENTATION_TYPES.HORIZONTAL) {
       return Meta.DisplayDirection.RIGHT;
     } else {
       return Meta.DisplayDirection.DOWN;
     }
   } else if (position === POSITION.BEFORE) {
-    if (orientaton === ORIENTATION_TYPES.HORIZONTAL) {
+    if (orientation === ORIENTATION_TYPES.HORIZONTAL) {
       return Meta.DisplayDirection.LEFT;
     } else {
       return Meta.DisplayDirection.UP;

--- a/lib/prefs/appearance.js
+++ b/lib/prefs/appearance.js
@@ -1,7 +1,7 @@
 // Gnome imports
 import Adw from "gi://Adw";
 import GObject from "gi://GObject";
-import Gdk from "gi://Gdk?version=4.0";
+import Gdk from "gi://Gdk";
 
 // Extension imports
 import { gettext as _ } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";

--- a/lib/prefs/keyboard.js
+++ b/lib/prefs/keyboard.js
@@ -1,7 +1,7 @@
 // Gnome imports
 import Adw from "gi://Adw";
 import GObject from "gi://GObject";
-import Gtk from "gi://Gtk?version=4.0";
+import Gtk from "gi://Gtk";
 
 // Extension Imports
 import { gettext as _ } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";

--- a/lib/prefs/settings.js
+++ b/lib/prefs/settings.js
@@ -1,6 +1,6 @@
 // Gnome imports
 import Adw from "gi://Adw";
-import Gtk from "gi://Gtk?version=4.0";
+import Gtk from "gi://Gtk";
 import GObject from "gi://GObject";
 
 // Shared state
@@ -98,7 +98,7 @@ export class SettingsPage extends PreferencesPage {
         new DropDownRow({
           title: _("Default Drag-and-Drop Center Layout"),
           settings,
-          type: 's',
+          type: "s",
           bind: "dnd-center-layout",
           items: [
             { id: "tabbed", name: _("Tabbed") },

--- a/lib/prefs/widgets.js
+++ b/lib/prefs/widgets.js
@@ -2,8 +2,8 @@
 
 import Adw from "gi://Adw";
 import Gio from "gi://Gio";
-import Gdk from "gi://Gdk?version=4.0";
-import Gtk from "gi://Gtk?version=4.0";
+import Gdk from "gi://Gdk";
+import Gtk from "gi://Gtk";
 import GObject from "gi://GObject";
 
 // GNOME imports
@@ -174,7 +174,7 @@ export class DropDownRow extends Adw.ActionRow {
   #onSelected() {
     this.selected = this.dropdown.selected;
     const { id } = this.items[this.selected];
-    Logger.debug('setting', id, this.selected);
+    Logger.debug("setting", id, this.selected);
     this.#set(this.bind, id);
   }
 
@@ -291,4 +291,3 @@ export class RadioRow extends Adw.ActionRow {
     this.add_suffix(hbox);
   }
 }
-

--- a/prefs.js
+++ b/prefs.js
@@ -17,8 +17,8 @@
  */
 
 // Gnome imports
-import Gdk from "gi://Gdk?version=4.0";
-import Gtk from "gi://Gtk?version=4.0";
+import Gdk from "gi://Gdk";
+import Gtk from "gi://Gtk";
 
 import { ExtensionPreferences } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
 
@@ -27,7 +27,7 @@ import { AppearancePage } from "./lib/prefs/appearance.js";
 import { WorkspacePage } from "./lib/prefs/workspace.js";
 import { SettingsPage } from "./lib/prefs/settings.js";
 
-export default class ForgeExtentionPreferences extends ExtensionPreferences {
+export default class ForgeExtensionPreferences extends ExtensionPreferences {
   settings = this.getSettings();
 
   kbdSettings = this.getSettings("org.gnome.shell.extensions.forge.keybindings");


### PR DESCRIPTION
forge-ext's extension, "Forge", version 74 has a new review:

JustPerfection posted a review on September 18, 2023:

1. Please remove the version from imports,
    because parent is the owner of prefs window and already specified the version:

    - line 20-21 prefs.js
    - line 4 lib/prefs/keyboard.js
    - line 4 lib/prefs/appearance.js
    - line 5-6 lib/prefs/widgets.js
    - line 3 lib/prefs/settings.js

2. Typo :p in

    - line 30 prefs.js (class name)
    - line 199 lib/extension/utils.js `orientaton`

3. You need to create objects on enable and null them out in disable (line 34 and 36 extension.js).
    Garbage collector cannot do it&#x27;s job otherwise.

4. Selective disable is not allowed (line 69 extension.js):
    https://gjs.guide/extensions/review-guidelines/review-guidelines.html#session-modes

Please use the review page to follow up:

https://extensions.gnome.org/review/45065