### PR TITLE
Add not include filter

### DIFF
--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -2457,7 +2457,16 @@ export class WindowManager extends GObject.Object {
             matchTitle = kf.wmTitle === windowTitle;
           } else {
             let titles = kf.wmTitle.split(",");
-            matchTitle = titles.filter((t) => windowTitle && windowTitle.includes(t)).length > 0;
+            matchTitle = titles.filter((t) => {
+              if (windowTitle) {
+                if (t.startsWith('!')) {
+                  return !windowTitle.includes(t.slice(1))
+                } else {
+                  return windowTitle.includes(t)
+                }
+              }
+              return false
+            }).length > 0;
           }
         }
         if (kf.wmClass) {


### PR DESCRIPTION
If the title filter starts with a `!`, then every window that does not contain the title match the filter.

This can be useful in cases like Firefox where the main window contains a string but not the others (cf. #285) 