### PR TITLE
DND to center option: don't tab/stack, swaps windows instead

### DIFF
--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -1845,6 +1845,7 @@ export class WindowManager extends GObject.Object {
       const horizontal = parentNodeTarget.isHSplit() || parentNodeTarget.isTabbed();
       const isMonParent = parentNodeTarget.nodeType === NODE_TYPES.MONITOR;
       const isConParent = parentNodeTarget.nodeType === NODE_TYPES.CON;
+      const centerLayout = this.ext.settings.get_string("dnd-center-layout").toUpperCase();
       const stacked = parentNodeTarget.isStacked();
       const tabbed = parentNodeTarget.isTabbed();
       const stackedOrTabbed = stacked || tabbed;
@@ -1942,28 +1943,35 @@ export class WindowManager extends GObject.Object {
       const isCenter = Utils.rectContainsPoint(centerRegion, currPointer);
 
       if (isCenter) {
-        if (stackedOrTabbed) {
-          containerNode = parentNodeTarget;
-          referenceNode = null;
+        if (centerLayout == "SWAP") {
+          referenceNode = nodeWinAtPointer;
           previewParams = {
-            className: stacked ? "window-tilepreview-stacked" : "window-tilepreview-tabbed",
             targetRect: targetRect,
           };
         } else {
-          if (isMonParent) {
-            childNode.createCon = true;
+          if (stackedOrTabbed) {
             containerNode = parentNodeTarget;
-            referenceNode = nodeWinAtPointer;
+            referenceNode = null;
             previewParams = {
+              className: stacked ? "window-tilepreview-stacked" : "window-tilepreview-tabbed",
               targetRect: targetRect,
             };
           } else {
-            containerNode = parentNodeTarget;
-            referenceNode = null;
-            const parentTargetRect = this.tree.processGap(parentNodeTarget);
-            previewParams = {
-              targetRect: parentTargetRect,
-            };
+            if (isMonParent) {
+              childNode.createCon = true;
+              containerNode = parentNodeTarget;
+              referenceNode = nodeWinAtPointer;
+              previewParams = {
+                targetRect: targetRect,
+              };
+            } else {
+              containerNode = parentNodeTarget;
+              referenceNode = null;
+              const parentTargetRect = this.tree.processGap(parentNodeTarget);
+              previewParams = {
+                targetRect: parentTargetRect,
+              };
+            }
           }
         }
       } else if (isLeft) {
@@ -2142,7 +2150,6 @@ export class WindowManager extends GObject.Object {
           } else if (isTop || isBottom) {
             childNode.layout = LAYOUT_TYPES.VSPLIT;
           } else if (isCenter) {
-            const centerLayout = this.ext.settings.get_string("dnd-center-layout").toUpperCase();
             childNode.layout = LAYOUT_TYPES[centerLayout];
           }
         } else if (childNode.detachWindow) {
@@ -2150,6 +2157,9 @@ export class WindowManager extends GObject.Object {
             isLeft || isRight ? ORIENTATION_TYPES.HORIZONTAL : ORIENTATION_TYPES.VERTICAL;
           this.tree.split(childNode, orientation);
           containerNode.insertBefore(childNode.parentNode, referenceNode);
+        } else if (isCenter && centerLayout == "SWAP") {
+          this.tree.swapPairs(referenceNode, focusNodeWindow)
+          this.renderTree("drag-swap");
         } else {
           // Child Node is a WINDOW
           containerNode.insertBefore(childNode, referenceNode);
@@ -2159,7 +2169,6 @@ export class WindowManager extends GObject.Object {
             if (!stackedOrTabbed) containerNode.layout = LAYOUT_TYPES.VSPLIT;
           } else if (isCenter) {
             if (containerNode.isHSplit() || containerNode.isVSplit()) {
-              const centerLayout = this.ext.settings.get_string("dnd-center-layout").toUpperCase();
               containerNode.layout = LAYOUT_TYPES[centerLayout];
             }
           }

--- a/lib/prefs/settings.js
+++ b/lib/prefs/settings.js
@@ -101,6 +101,7 @@ export class SettingsPage extends PreferencesPage {
           type: "s",
           bind: "dnd-center-layout",
           items: [
+            { id: "swap", name: _("Swap") },
             { id: "tabbed", name: _("Tabbed") },
             { id: "stacked", name: _("Stacked") },
           ],

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -123,6 +123,14 @@
   background-color: rgba(247, 162, 43, 0.3);
 }
 
+.window-tilepreview-swap {
+  border-width: 1px;
+  border-color: rgba(162, 247, 43, 0.4);
+  border-style: solid;
+  border-radius: 14px;
+  background-color: rgba(162, 247, 43, 0.4);
+}
+
 .window-tilepreview-tabbed {
   border-width: 1px;
   border-color: rgba(18, 199, 224, 0.4);


### PR DESCRIPTION
I often find myself in a situation where I have a layout, but want to rearrange windows inside that layout. Currently there's no way to do it quickly with a mouse without ruining the layout. You can only be clicking and using "swap with previous" from keyboard, which is annoying. This PR adds an option to not create stacked/tabbed layout on drag and drop to a window center, and to just swap windows instead. This makes it much easier to rearrange windows inside the layout, and tabbed/stacked layouts are still available via keyboard shortcuts.