### PR TITLE
Remove duplicated message definition in pt_BR translation

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -259,10 +259,6 @@ msgstr "Habilitar a exibição do Forge nas configurações rápidas"
 msgid "Behavior"
 msgstr "Comportamento"
 
-#: lib/prefs/settings.js:133
-msgid "Behavior"
-msgstr "Comportamento"
-
 #: lib/prefs/settings.js:136
 msgid "Move Pointer to the Focused Window"
 msgstr "Mover o Ponteiro para Janela com Foco"


### PR DESCRIPTION
This fixes error during build

```
xgettext --from-code=UTF-8 --output=po/forge.pot --package-name "Forge" ./prefs.js ./extension.js ./lib/**/*.js
msgfmt -c po/pt_BR.po -o po/pt_BR.mo
po/pt_BR.po:263: duplicate message definition...
po/pt_BR.po:260: ...this is the location of the first definition
msgfmt: found 1 fatal error
make: *** [Makefile:51: po/pt_BR.mo] Error 1
```