### PR TITLE
Fix error 'metaWindow.get_title is not a function'

### DIFF
--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -1611,7 +1611,7 @@ export class WindowManager extends GObject.Object {
     let nodeWindow;
     nodeWindow = this.tree.findNodeByActor(actor);
 
-    if (nodeWindow && nodeWindow.isWindow()) {
+    if (nodeWindow?.isWindow()) {
       this.tree.removeNode(nodeWindow);
       this.renderTree("window-destroy-quick", true);
       this.removeFloatOverride(nodeWindow.nodeValue, true);

--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -1611,10 +1611,10 @@ export class WindowManager extends GObject.Object {
     let nodeWindow;
     nodeWindow = this.tree.findNodeByActor(actor);
 
-    if (nodeWindow) {
+    if (nodeWindow && nodeWindow.isWindow()) {
       this.tree.removeNode(nodeWindow);
       this.renderTree("window-destroy-quick", true);
-      this.removeFloatOverride(nodeWindow, false, true);
+      this.removeFloatOverride(nodeWindow.nodeValue, true);
     }
 
     // find the next attachNode here

--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -77,9 +77,8 @@ export class WindowManager extends GObject.Object {
     Logger.info("forge initialized");
   }
 
-  addFloatOverride(metaWindow, nonPersistent) {
+  addFloatOverride(metaWindow, withWmId) {
     let overrides = this.windowProps.overrides;
-    let wmTitle = metaWindow.get_title();
     let wmClass = metaWindow.get_wm_class();
     let wmId = metaWindow.get_id();
 
@@ -89,26 +88,24 @@ export class WindowManager extends GObject.Object {
     }
     overrides.push({
       wmClass: wmClass,
-      wmId: nonPersistent ? wmId : undefined,
+      wmId: withWmId ? wmId : undefined,
       mode: "float",
     });
     this.windowProps.overrides = overrides;
     this.ext.configMgr.windowProps = this.windowProps;
   }
 
-  removeFloatOverride(metaWindow, nonPersistent) {
+  removeFloatOverride(metaWindow, withWmId) {
     let overrides = this.windowProps.overrides;
-    let wmTitle = metaWindow.get_title();
     let wmClass = metaWindow.get_wm_class();
     let wmId = metaWindow.get_id();
-
     overrides = overrides.filter(
       (override) =>
         !(
           override.wmClass === wmClass &&
+          // rules with a Title are written by the user and peristent
           !override.wmTitle &&
-          // persistent or tagged as tmp
-          (!nonPersistent || override.wmId === wmId)
+          (!withWmId || override.wmId === wmId)
         )
     );
 
@@ -121,18 +118,18 @@ export class WindowManager extends GObject.Object {
     if (!nodeWindow || !(action || action.mode)) return;
     if (nodeWindow.nodeType !== NODE_TYPES.WINDOW) return;
 
-    let nonPersistent = action.name === "FloatToggle";
+    let withWmId = action.name === "FloatToggle";
     let floatingExempt = this.isFloatingExempt(metaWindow);
 
     if (floatingExempt) {
-      this.removeFloatOverride(metaWindow, nonPersistent);
+      this.removeFloatOverride(metaWindow, withWmId);
       if (!this.isActiveWindowWorkspaceTiled(metaWindow)) {
         nodeWindow.mode = WINDOW_MODES.FLOAT;
       } else {
         nodeWindow.mode = WINDOW_MODES.TILE;
       }
     } else {
-      this.addFloatOverride(metaWindow, nonPersistent);
+      this.addFloatOverride(metaWindow, withWmId);
       nodeWindow.mode = WINDOW_MODES.FLOAT;
     }
   }


### PR DESCRIPTION
This was the cause of ghosts windows with dynamic workspaces: Closing a window in a workspace reduced the number of workspaces above it. Windows in these workspaces considered that there was still another window, and finished tiling with a ghost window.

Error log:

```
JS ERROR: TypeError: metaWindow.get_title is not a function
removeFloatOverride@file:///var/home/user/.local/share/gnome-shell/extensions/forge@jmmaranan.com/lib/extension/window.js:106:30
windowDestroy@file:///var/home/user/.local/share/gnome-shell/extensions/forge@jmmaranan.com/lib/extension/window.js:1623:12
_destroyWindowDone@resource:///org/gnome/shell/ui/windowManager.js:1555:21
onStopped@resource:///org/gnome/shell/ui/windowManager.js:1523:39
_makeEaseCallback/<@resource:///org/gnome/shell/ui/environment.js:84:22
_easeActor/<@resource:///org/gnome/shell/ui/environment.js:173:64
@resource:///org/gnome/shell/ui/init.js:21:20

