### PR TITLE
Fix drag resize

### DIFF
--- a/lib/extension/utils.js
+++ b/lib/extension/utils.js
@@ -266,6 +266,10 @@ export function allowResizeGrabOp(grabOp) {
     grabOp === Meta.GrabOp.RESIZING_E ||
     grabOp === Meta.GrabOp.RESIZING_W ||
     grabOp === Meta.GrabOp.RESIZING_S ||
+    grabOp === Meta.GrabOp.RESIZING_NE ||
+    grabOp === Meta.GrabOp.RESIZING_NW ||
+    grabOp === Meta.GrabOp.RESIZING_SE ||
+    grabOp === Meta.GrabOp.RESIZING_SW ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_N ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_E ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_W ||
@@ -280,6 +284,10 @@ export function grabMode(grabOp) {
     grabOp === Meta.GrabOp.RESIZING_E ||
     grabOp === Meta.GrabOp.RESIZING_W ||
     grabOp === Meta.GrabOp.RESIZING_S ||
+    grabOp === Meta.GrabOp.RESIZING_NE ||
+    grabOp === Meta.GrabOp.RESIZING_NW ||
+    grabOp === Meta.GrabOp.RESIZING_SE ||
+    grabOp === Meta.GrabOp.RESIZING_SW ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_N ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_E ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_W ||
@@ -295,6 +303,21 @@ export function grabMode(grabOp) {
     return GRAB_TYPES.MOVING;
   }
   return GRAB_TYPES.UNKNOWN;
+}
+
+export function decomposeGrabOp(grabOp) {
+  switch (grabOp) {
+    case Meta.GrabOp.RESIZING_NE:
+      return [Meta.GrabOp.RESIZING_N, Meta.GrabOp.RESIZING_E];
+    case Meta.GrabOp.RESIZING_NW:
+      return [Meta.GrabOp.RESIZING_N, Meta.GrabOp.RESIZING_W];
+    case Meta.GrabOp.RESIZING_SE:
+      return [Meta.GrabOp.RESIZING_S, Meta.GrabOp.RESIZING_E];
+    case Meta.GrabOp.RESIZING_SW:
+      return [Meta.GrabOp.RESIZING_S, Meta.GrabOp.RESIZING_W];
+    default:
+      return [grabOp];
+  }
 }
 
 export function directionFromGrab(grabOp) {

--- a/lib/extension/utils.js
+++ b/lib/extension/utils.js
@@ -32,6 +32,17 @@ import { GRAB_TYPES } from "./window.js";
 
 const [major] = PACKAGE_VERSION.split(".").map((s) => Number(s));
 
+// Extend GrabOp enum for SUPER
+const SUPER_BIT = 1 << 10;
+Meta.GrabOp.SUPER_RESIZE_N = Meta.GrabOp.RESIZING_N | SUPER_BIT;
+Meta.GrabOp.SUPER_RESIZE_E = Meta.GrabOp.RESIZING_E | SUPER_BIT;
+Meta.GrabOp.SUPER_RESIZE_W = Meta.GrabOp.RESIZING_W | SUPER_BIT;
+Meta.GrabOp.SUPER_RESIZE_S = Meta.GrabOp.RESIZING_S | SUPER_BIT;
+Meta.GrabOp.SUPER_RESIZE_NE = Meta.GrabOp.RESIZING_NE | SUPER_BIT;
+Meta.GrabOp.SUPER_RESIZE_NW = Meta.GrabOp.RESIZING_NW | SUPER_BIT;
+Meta.GrabOp.SUPER_RESIZE_SE = Meta.GrabOp.RESIZING_SE | SUPER_BIT;
+Meta.GrabOp.SUPER_RESIZE_SW = Meta.GrabOp.RESIZING_SW | SUPER_BIT;
+
 /**
  *
  * Turns an array into an immutable enum-like object
@@ -270,6 +281,14 @@ export function allowResizeGrabOp(grabOp) {
     grabOp === Meta.GrabOp.RESIZING_NW ||
     grabOp === Meta.GrabOp.RESIZING_SE ||
     grabOp === Meta.GrabOp.RESIZING_SW ||
+    grabOp === Meta.GrabOp.SUPER_RESIZE_N ||
+    grabOp === Meta.GrabOp.SUPER_RESIZE_E ||
+    grabOp === Meta.GrabOp.SUPER_RESIZE_W ||
+    grabOp === Meta.GrabOp.SUPER_RESIZE_S ||
+    grabOp === Meta.GrabOp.SUPER_RESIZE_NE ||
+    grabOp === Meta.GrabOp.SUPER_RESIZE_NW ||
+    grabOp === Meta.GrabOp.SUPER_RESIZE_SE ||
+    grabOp === Meta.GrabOp.SUPER_RESIZE_SW ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_N ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_E ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_W ||
@@ -288,6 +307,14 @@ export function grabMode(grabOp) {
     grabOp === Meta.GrabOp.RESIZING_NW ||
     grabOp === Meta.GrabOp.RESIZING_SE ||
     grabOp === Meta.GrabOp.RESIZING_SW ||
+    grabOp === Meta.GrabOp.SUPER_RESIZE_N ||
+    grabOp === Meta.GrabOp.SUPER_RESIZE_E ||
+    grabOp === Meta.GrabOp.SUPER_RESIZE_W ||
+    grabOp === Meta.GrabOp.SUPER_RESIZE_S ||
+    grabOp === Meta.GrabOp.SUPER_RESIZE_NE ||
+    grabOp === Meta.GrabOp.SUPER_RESIZE_NW ||
+    grabOp === Meta.GrabOp.SUPER_RESIZE_SE ||
+    grabOp === Meta.GrabOp.SUPER_RESIZE_SW ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_N ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_E ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_W ||
@@ -315,6 +342,22 @@ export function decomposeGrabOp(grabOp) {
       return [Meta.GrabOp.RESIZING_S, Meta.GrabOp.RESIZING_E];
     case Meta.GrabOp.RESIZING_SW:
       return [Meta.GrabOp.RESIZING_S, Meta.GrabOp.RESIZING_W];
+    case Meta.GrabOp.SUPER_RESIZE_NE:
+      return [Meta.GrabOp.RESIZING_N, Meta.GrabOp.RESIZING_E];
+    case Meta.GrabOp.SUPER_RESIZE_NW:
+      return [Meta.GrabOp.RESIZING_N, Meta.GrabOp.RESIZING_W];
+    case Meta.GrabOp.SUPER_RESIZE_SE:
+      return [Meta.GrabOp.RESIZING_S, Meta.GrabOp.RESIZING_E];
+    case Meta.GrabOp.SUPER_RESIZE_SW:
+      return [Meta.GrabOp.RESIZING_S, Meta.GrabOp.RESIZING_W];
+    case Meta.GrabOp.SUPER_RESIZE_N:
+      return [Meta.GrabOp.RESIZING_N];
+    case Meta.GrabOp.SUPER_RESIZE_E:
+      return [Meta.GrabOp.RESIZING_E];
+    case Meta.GrabOp.SUPER_RESIZE_W:
+      return [Meta.GrabOp.RESIZING_W];
+    case Meta.GrabOp.SUPER_RESIZE_S:
+      return [Meta.GrabOp.RESIZING_S];
     default:
       return [grabOp];
   }

--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -2348,143 +2348,145 @@ export class WindowManager extends GObject.Object {
 
   _handleResizing(focusNodeWindow) {
     if (!focusNodeWindow || focusNodeWindow.isFloat()) return;
-    let grabOp = this.grabOp;
-    let initGrabOp = focusNodeWindow.initGrabOp;
-    let direction = Utils.directionFromGrab(grabOp);
-    let orientation = Utils.orientationFromGrab(grabOp);
-    let parentNodeForFocus = focusNodeWindow.parentNode;
-    let position = Utils.positionFromGrabOp(grabOp);
-    // normalize the rect without gaps
-    let frameRect = this.focusMetaWindow.get_frame_rect();
-    let gaps = this.calculateGaps(focusNodeWindow);
-    let currentRect = Utils.removeGapOnRect(frameRect, gaps);
-    let firstRect;
-    let secondRect;
-    let parentRect;
-    let resizePairForWindow;
+    let grabOps = Utils.decomposeGrabOp(this.grabOp);
+    for (let grabOp of grabOps) {
+      let initGrabOp = focusNodeWindow.initGrabOp;
+      let direction = Utils.directionFromGrab(grabOp);
+      let orientation = Utils.orientationFromGrab(grabOp);
+      let parentNodeForFocus = focusNodeWindow.parentNode;
+      let position = Utils.positionFromGrabOp(grabOp);
+      // normalize the rect without gaps
+      let frameRect = this.focusMetaWindow.get_frame_rect();
+      let gaps = this.calculateGaps(focusNodeWindow);
+      let currentRect = Utils.removeGapOnRect(frameRect, gaps);
+      let firstRect;
+      let secondRect;
+      let parentRect;
+      let resizePairForWindow;
 
-    if (initGrabOp === Meta.GrabOp.RESIZING_UNKNOWN) {
-      // the direction is null so do not process yet below.
-      return;
-    } else {
-      resizePairForWindow = this.tree.nextVisible(focusNodeWindow, direction);
-    }
-
-    let sameParent = resizePairForWindow
-      ? resizePairForWindow.parentNode === focusNodeWindow.parentNode
-      : false;
-
-    if (orientation === ORIENTATION_TYPES.HORIZONTAL) {
-      if (sameParent) {
-        // use the window or con pairs
-        if (this.tree.getTiledChildren(parentNodeForFocus.childNodes).length <= 1) {
-          return;
-        }
-
-        firstRect = focusNodeWindow.initRect;
-        if (resizePairForWindow) {
-          if (
-            !this.floatingWindow(resizePairForWindow) &&
-            !this.minimizedWindow(resizePairForWindow)
-          ) {
-            secondRect = resizePairForWindow.rect;
-          } else {
-            // TODO try to get the next resize pair?
-          }
-        }
-
-        if (!firstRect || !secondRect) {
-          return;
-        }
-
-        parentRect = parentNodeForFocus.rect;
-        let changePx = currentRect.width - firstRect.width;
-        let firstPercent = (firstRect.width + changePx) / parentRect.width;
-        let secondPercent = (secondRect.width - changePx) / parentRect.width;
-        focusNodeWindow.percent = firstPercent;
-        resizePairForWindow.percent = secondPercent;
+      if (initGrabOp === Meta.GrabOp.RESIZING_UNKNOWN) {
+        // the direction is null so do not process yet below.
+        return;
       } else {
-        // use the parent pairs (con to another con or window)
-        if (resizePairForWindow && resizePairForWindow.parentNode) {
-          if (this.tree.getTiledChildren(resizePairForWindow.parentNode.childNodes).length <= 1) {
+        resizePairForWindow = this.tree.nextVisible(focusNodeWindow, direction);
+      }
+
+      let sameParent = resizePairForWindow
+        ? resizePairForWindow.parentNode === focusNodeWindow.parentNode
+        : false;
+
+      if (orientation === ORIENTATION_TYPES.HORIZONTAL) {
+        if (sameParent) {
+          // use the window or con pairs
+          if (this.tree.getTiledChildren(parentNodeForFocus.childNodes).length <= 1) {
             return;
           }
-          let firstWindowRect = focusNodeWindow.initRect;
-          let index = resizePairForWindow.index;
-          if (position === POSITION.BEFORE) {
-            // Find the opposite node
-            index = index + 1;
-          } else {
-            index = index - 1;
+
+          firstRect = focusNodeWindow.initRect;
+          if (resizePairForWindow) {
+            if (
+              !this.floatingWindow(resizePairForWindow) &&
+              !this.minimizedWindow(resizePairForWindow)
+            ) {
+              secondRect = resizePairForWindow.rect;
+            } else {
+              // TODO try to get the next resize pair?
+            }
           }
-          parentNodeForFocus = resizePairForWindow.parentNode.childNodes[index];
-          firstRect = parentNodeForFocus.rect;
-          secondRect = resizePairForWindow.rect;
+
           if (!firstRect || !secondRect) {
             return;
           }
 
-          parentRect = parentNodeForFocus.parentNode.rect;
-          let changePx = currentRect.width - firstWindowRect.width;
+          parentRect = parentNodeForFocus.rect;
+          let changePx = currentRect.width - firstRect.width;
           let firstPercent = (firstRect.width + changePx) / parentRect.width;
           let secondPercent = (secondRect.width - changePx) / parentRect.width;
-          parentNodeForFocus.percent = firstPercent;
+          focusNodeWindow.percent = firstPercent;
           resizePairForWindow.percent = secondPercent;
-        }
-      }
-    } else if (orientation === ORIENTATION_TYPES.VERTICAL) {
-      if (sameParent) {
-        // use the window or con pairs
-        if (this.tree.getTiledChildren(parentNodeForFocus.childNodes).length <= 1) {
-          return;
-        }
-        firstRect = focusNodeWindow.initRect;
-        if (resizePairForWindow) {
-          if (
-            !this.floatingWindow(resizePairForWindow) &&
-            !this.minimizedWindow(resizePairForWindow)
-          ) {
+        } else {
+          // use the parent pairs (con to another con or window)
+          if (resizePairForWindow && resizePairForWindow.parentNode) {
+            if (this.tree.getTiledChildren(resizePairForWindow.parentNode.childNodes).length <= 1) {
+              return;
+            }
+            let firstWindowRect = focusNodeWindow.initRect;
+            let index = resizePairForWindow.index;
+            if (position === POSITION.BEFORE) {
+              // Find the opposite node
+              index = index + 1;
+            } else {
+              index = index - 1;
+            }
+            parentNodeForFocus = resizePairForWindow.parentNode.childNodes[index];
+            firstRect = parentNodeForFocus.rect;
             secondRect = resizePairForWindow.rect;
-          } else {
-            // TODO try to get the next resize pair?
+            if (!firstRect || !secondRect) {
+              return;
+            }
+
+            parentRect = parentNodeForFocus.parentNode.rect;
+            let changePx = currentRect.width - firstWindowRect.width;
+            let firstPercent = (firstRect.width + changePx) / parentRect.width;
+            let secondPercent = (secondRect.width - changePx) / parentRect.width;
+            parentNodeForFocus.percent = firstPercent;
+            resizePairForWindow.percent = secondPercent;
           }
         }
-        if (!firstRect || !secondRect) {
-          return;
-        }
-        parentRect = parentNodeForFocus.rect;
-        let changePx = currentRect.height - firstRect.height;
-        let firstPercent = (firstRect.height + changePx) / parentRect.height;
-        let secondPercent = (secondRect.height - changePx) / parentRect.height;
-        focusNodeWindow.percent = firstPercent;
-        resizePairForWindow.percent = secondPercent;
-      } else {
-        // use the parent pairs (con to another con or window)
-        if (resizePairForWindow && resizePairForWindow.parentNode) {
-          if (this.tree.getTiledChildren(resizePairForWindow.parentNode.childNodes).length <= 1) {
+      } else if (orientation === ORIENTATION_TYPES.VERTICAL) {
+        if (sameParent) {
+          // use the window or con pairs
+          if (this.tree.getTiledChildren(parentNodeForFocus.childNodes).length <= 1) {
             return;
           }
-          let firstWindowRect = focusNodeWindow.initRect;
-          let index = resizePairForWindow.index;
-          if (position === POSITION.BEFORE) {
-            // Find the opposite node
-            index = index + 1;
-          } else {
-            index = index - 1;
+          firstRect = focusNodeWindow.initRect;
+          if (resizePairForWindow) {
+            if (
+              !this.floatingWindow(resizePairForWindow) &&
+              !this.minimizedWindow(resizePairForWindow)
+            ) {
+              secondRect = resizePairForWindow.rect;
+            } else {
+              // TODO try to get the next resize pair?
+            }
           }
-          parentNodeForFocus = resizePairForWindow.parentNode.childNodes[index];
-          firstRect = parentNodeForFocus.rect;
-          secondRect = resizePairForWindow.rect;
           if (!firstRect || !secondRect) {
             return;
           }
-
-          parentRect = parentNodeForFocus.parentNode.rect;
-          let changePx = currentRect.height - firstWindowRect.height;
+          parentRect = parentNodeForFocus.rect;
+          let changePx = currentRect.height - firstRect.height;
           let firstPercent = (firstRect.height + changePx) / parentRect.height;
           let secondPercent = (secondRect.height - changePx) / parentRect.height;
-          parentNodeForFocus.percent = firstPercent;
+          focusNodeWindow.percent = firstPercent;
           resizePairForWindow.percent = secondPercent;
+        } else {
+          // use the parent pairs (con to another con or window)
+          if (resizePairForWindow && resizePairForWindow.parentNode) {
+            if (this.tree.getTiledChildren(resizePairForWindow.parentNode.childNodes).length <= 1) {
+              return;
+            }
+            let firstWindowRect = focusNodeWindow.initRect;
+            let index = resizePairForWindow.index;
+            if (position === POSITION.BEFORE) {
+              // Find the opposite node
+              index = index + 1;
+            } else {
+              index = index - 1;
+            }
+            parentNodeForFocus = resizePairForWindow.parentNode.childNodes[index];
+            firstRect = parentNodeForFocus.rect;
+            secondRect = resizePairForWindow.rect;
+            if (!firstRect || !secondRect) {
+              return;
+            }
+
+            parentRect = parentNodeForFocus.parentNode.rect;
+            let changePx = currentRect.height - firstWindowRect.height;
+            let firstPercent = (firstRect.height + changePx) / parentRect.height;
+            let secondPercent = (secondRect.height - changePx) / parentRect.height;
+            parentNodeForFocus.percent = firstPercent;
+            resizePairForWindow.percent = secondPercent;
+          }
         }
       }
     }


### PR DESCRIPTION
fixes #269
- makes it possible to scale windows by the corner
- enables scaling with secondary key and super+middleclick

The diff for `lib/extension/window.js` looks complicated but I really only added a loop.