### PR TITLE
refactor super resize

### DIFF
--- a/lib/extension/utils.js
+++ b/lib/extension/utils.js
@@ -32,17 +32,6 @@ import { GRAB_TYPES } from "./window.js";
 
 const [major] = PACKAGE_VERSION.split(".").map((s) => Number(s));
 
-// Extend GrabOp enum for SUPER
-const SUPER_BIT = 1 << 10;
-Meta.GrabOp.SUPER_RESIZE_N = Meta.GrabOp.RESIZING_N | SUPER_BIT;
-Meta.GrabOp.SUPER_RESIZE_E = Meta.GrabOp.RESIZING_E | SUPER_BIT;
-Meta.GrabOp.SUPER_RESIZE_W = Meta.GrabOp.RESIZING_W | SUPER_BIT;
-Meta.GrabOp.SUPER_RESIZE_S = Meta.GrabOp.RESIZING_S | SUPER_BIT;
-Meta.GrabOp.SUPER_RESIZE_NE = Meta.GrabOp.RESIZING_NE | SUPER_BIT;
-Meta.GrabOp.SUPER_RESIZE_NW = Meta.GrabOp.RESIZING_NW | SUPER_BIT;
-Meta.GrabOp.SUPER_RESIZE_SE = Meta.GrabOp.RESIZING_SE | SUPER_BIT;
-Meta.GrabOp.SUPER_RESIZE_SW = Meta.GrabOp.RESIZING_SW | SUPER_BIT;
-
 /**
  *
  * Turns an array into an immutable enum-like object
@@ -272,6 +261,7 @@ export function positionFromGrabOp(grabOp) {
 }
 
 export function allowResizeGrabOp(grabOp) {
+  grabOp &= ~1024; // ignore META_GRAB_OP_WINDOW_FLAG_UNCONSTRAINED
   return (
     grabOp === Meta.GrabOp.RESIZING_N ||
     grabOp === Meta.GrabOp.RESIZING_E ||
@@ -281,14 +271,6 @@ export function allowResizeGrabOp(grabOp) {
     grabOp === Meta.GrabOp.RESIZING_NW ||
     grabOp === Meta.GrabOp.RESIZING_SE ||
     grabOp === Meta.GrabOp.RESIZING_SW ||
-    grabOp === Meta.GrabOp.SUPER_RESIZE_N ||
-    grabOp === Meta.GrabOp.SUPER_RESIZE_E ||
-    grabOp === Meta.GrabOp.SUPER_RESIZE_W ||
-    grabOp === Meta.GrabOp.SUPER_RESIZE_S ||
-    grabOp === Meta.GrabOp.SUPER_RESIZE_NE ||
-    grabOp === Meta.GrabOp.SUPER_RESIZE_NW ||
-    grabOp === Meta.GrabOp.SUPER_RESIZE_SE ||
-    grabOp === Meta.GrabOp.SUPER_RESIZE_SW ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_N ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_E ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_W ||
@@ -298,6 +280,7 @@ export function allowResizeGrabOp(grabOp) {
 }
 
 export function grabMode(grabOp) {
+  grabOp &= ~1024; // ignore META_GRAB_OP_WINDOW_FLAG_UNCONSTRAINED
   if (
     grabOp === Meta.GrabOp.RESIZING_N ||
     grabOp === Meta.GrabOp.RESIZING_E ||
@@ -307,14 +290,6 @@ export function grabMode(grabOp) {
     grabOp === Meta.GrabOp.RESIZING_NW ||
     grabOp === Meta.GrabOp.RESIZING_SE ||
     grabOp === Meta.GrabOp.RESIZING_SW ||
-    grabOp === Meta.GrabOp.SUPER_RESIZE_N ||
-    grabOp === Meta.GrabOp.SUPER_RESIZE_E ||
-    grabOp === Meta.GrabOp.SUPER_RESIZE_W ||
-    grabOp === Meta.GrabOp.SUPER_RESIZE_S ||
-    grabOp === Meta.GrabOp.SUPER_RESIZE_NE ||
-    grabOp === Meta.GrabOp.SUPER_RESIZE_NW ||
-    grabOp === Meta.GrabOp.SUPER_RESIZE_SE ||
-    grabOp === Meta.GrabOp.SUPER_RESIZE_SW ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_N ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_E ||
     grabOp === Meta.GrabOp.KEYBOARD_RESIZING_W ||
@@ -333,6 +308,7 @@ export function grabMode(grabOp) {
 }
 
 export function decomposeGrabOp(grabOp) {
+  grabOp &= ~1024; // ignore META_GRAB_OP_WINDOW_FLAG_UNCONSTRAINED
   switch (grabOp) {
     case Meta.GrabOp.RESIZING_NE:
       return [Meta.GrabOp.RESIZING_N, Meta.GrabOp.RESIZING_E];
@@ -342,22 +318,6 @@ export function decomposeGrabOp(grabOp) {
       return [Meta.GrabOp.RESIZING_S, Meta.GrabOp.RESIZING_E];
     case Meta.GrabOp.RESIZING_SW:
       return [Meta.GrabOp.RESIZING_S, Meta.GrabOp.RESIZING_W];
-    case Meta.GrabOp.SUPER_RESIZE_NE:
-      return [Meta.GrabOp.RESIZING_N, Meta.GrabOp.RESIZING_E];
-    case Meta.GrabOp.SUPER_RESIZE_NW:
-      return [Meta.GrabOp.RESIZING_N, Meta.GrabOp.RESIZING_W];
-    case Meta.GrabOp.SUPER_RESIZE_SE:
-      return [Meta.GrabOp.RESIZING_S, Meta.GrabOp.RESIZING_E];
-    case Meta.GrabOp.SUPER_RESIZE_SW:
-      return [Meta.GrabOp.RESIZING_S, Meta.GrabOp.RESIZING_W];
-    case Meta.GrabOp.SUPER_RESIZE_N:
-      return [Meta.GrabOp.RESIZING_N];
-    case Meta.GrabOp.SUPER_RESIZE_E:
-      return [Meta.GrabOp.RESIZING_E];
-    case Meta.GrabOp.SUPER_RESIZE_W:
-      return [Meta.GrabOp.RESIZING_W];
-    case Meta.GrabOp.SUPER_RESIZE_S:
-      return [Meta.GrabOp.RESIZING_S];
     default:
       return [grabOp];
   }


### PR DESCRIPTION
This is an update to https://github.com/forge-ext/forge/pull/370 based on the feedback from the EGO admin

Probably changing the `Meta.GrabOp` directly isn't the right way.
I looked at the code from Tiling-Assistant and they just ignore the bit. (https://github.com/Leleat/Tiling-Assistant/pull/253/files)
So here is the updated version similar to the Tiling-Assistant fix.
I think it's simpler this way and hope it gets approved :)