### PR TITLE
Correct vertical position of tabbed windows

### DIFF
--- a/lib/extension/tree.js
+++ b/lib/extension/tree.js
@@ -1511,7 +1511,6 @@ export class Tree extends Node {
 
           if (gap === 0) {
             adjustY = renderRect.y;
-            nodeY = renderRect.y + params.stackedHeight + adjust / 4;
           }
 
           let decoration = node.decoration;


### PR DESCRIPTION
Currently when the gap is zero, windows below tabs are repositioned slightly downward. This causes the windows to exceed the bottom of the screen and results in [a small gap](https://github.com/forge-ext/forge/issues/391) between the window and tabs. This repositioning is unnecessary, so remove it.

Before and after—note the recovery of the bottom border of the window:

![screenshots of before and after](https://github.com/forge-ext/forge/assets/1844746/dca8daac-cfb7-440f-8f0e-67fd69a45ed7)
