### PR TITLE
Add Gnome 47 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "gettext-domain": "forge",
   "uuid": "forge@jmmaranan.com",
   "settings-schema": "org.gnome.shell.extensions.forge",
-  "shell-version": ["45", "46"],
+  "shell-version": ["45", "46", "47"],
   "session-modes": ["user", "unlock-dialog"],
   "version": "1.2-alpha",
   "url": "https://github.com/forge-ext/forge"


### PR DESCRIPTION
All that is needed is adding 47 to metadata.json

![Screenshot From 2024-09-07 21-33-35](https://github.com/user-attachments/assets/0f679bc1-7737-4fa2-b808-bce770c7bf8a)
![image](https://github.com/user-attachments/assets/6e2962c0-8ba3-4669-9f70-b59b0c77ede5)
