### PR TITLE
fix: hide border of unmanaged windows

### DIFF
--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -891,16 +891,20 @@ export class WindowManager extends GObject.Object {
     });
   }
 
+  hideActorBorder(actor) {
+    if (actor.border) {
+      actor.border.hide();
+    }
+    if (actor.splitBorder) {
+      actor.splitBorder.hide();
+    }
+  }
+
   hideWindowBorders() {
     this.tree.nodeWindows.forEach((nodeWindow) => {
       let actor = nodeWindow.windowActor;
       if (actor) {
-        if (actor.border) {
-          actor.border.hide();
-        }
-        if (actor.splitBorder) {
-          actor.splitBorder.hide();
-        }
+        this.hideActorBorder(actor);
       }
       if (nodeWindow.parentNode.isTabbed()) {
         if (nodeWindow.tab) {
@@ -1409,6 +1413,9 @@ export class WindowManager extends GObject.Object {
             metaWindow.connect("size-changed", (_metaWindow) => {
               let from = "size-changed";
               this.updateMetaPositionSize(_metaWindow, from);
+            }),
+            metaWindow.connect("unmanaged", (_metaWindow) => {
+              this.hideActorBorder(windowActor);
             }),
             metaWindow.connect("focus", (_metaWindowFocus) => {
               this.queueEvent({


### PR DESCRIPTION
Fixes #257

When the window becomes `unmanaged`, it should be safe to hide the borders, which also fixes the visual bug mentioned in #257. 