### PR TITLE
feat: custom implementation of `Focus on Hover`

### DIFF
--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -45,6 +45,9 @@ import {
 } from "./tree.js";
 import { production } from "../shared/settings.js";
 
+// GJS imports
+const mainloop = imports.mainloop;
+
 /** @typedef {import('../../extension.js').default} ForgeExtension */
 
 export const WINDOW_MODES = Utils.createEnum(["FLOAT", "TILE", "GRAB_TILE", "DEFAULT"]);
@@ -74,7 +77,19 @@ export class WindowManager extends GObject.Object {
     this.eventQueue = new Queue();
     this.theme = this.ext.theme;
     this.lastFocusedWindow = null;
+    this.shouldFocusOnHover = this.ext.settings.get_boolean("focus-on-hover-enabled");
+
     Logger.info("forge initialized");
+
+    if (this.shouldFocusOnHover) {
+      // Start the pointer loop to observe the pointer position
+      // and change the focus window accordingly
+      this.pointerLoopInit();
+    }
+  }
+
+  pointerLoopInit() {
+    mainloop.timeout_add(16, this._focusWindowUnderPointer.bind(this));
   }
 
   addFloatOverride(metaWindow, withWmId) {
@@ -267,6 +282,14 @@ export class WindowManager extends GObject.Object {
       switch (settingName) {
         case "focus-border-toggle":
           this.renderTree(settingName);
+          break;
+        case "focus-on-hover-enabled":
+          this.shouldFocusOnHover = settings.get_boolean(settingName);
+
+          if (this.shouldFocusOnHover) {
+            this.pointerLoopInit();
+          }
+
           break;
         case "tiling-mode-enabled":
           this.renderTree(settingName);
@@ -2241,6 +2264,61 @@ export class WindowManager extends GObject.Object {
 
     let nodeWinAtPointer = this._findNodeWindowAtPointer(focusNodeWindow.nodeValue, pointerCoord);
     return nodeWinAtPointer;
+  }
+
+  /**
+   * Focus the window under the pointer and raise it.
+   *
+   * @returns {boolean} true if we should continue polling, false otherwise
+   */
+  _focusWindowUnderPointer() {
+    // Break the loop if the user has disabled the feature
+    if (!this.shouldFocusOnHover) return false;
+
+    // We don't want to focus windows when the overview is visible
+    if (Main.overview.visible) return true;
+
+    // Get the global mouse position
+    let pointer = global.get_pointer();
+
+    const metaWindow = this._getMetaWindowAtPointer(pointer);
+
+    if (metaWindow) {
+      // If window is not null, focus it
+      metaWindow.focus(global.get_current_time());
+      // Raise it to the top
+      metaWindow.raise();
+    }
+
+    // Continue polling
+    return true;
+  }
+
+  /**
+   * Get the Meta.Window at the pointer coordinates
+   *
+   * @param {[number, number]} pointer x and y coordinates
+   * @returns null if no window is found, otherwise the Meta.Window
+   */
+  _getMetaWindowAtPointer(pointer) {
+    const windows = global.get_window_actors();
+    const [x, y] = pointer;
+
+    // Iterate through the windows in reverse order to get the top-most window
+    for (let i = windows.length - 1; i >= 0; i--) {
+      let window = windows[i];
+      let metaWindow = window.meta_window;
+
+      let { x: wx, y: wy, width, height } = metaWindow.get_frame_rect();
+
+      // Check if the position is within the window bounds
+      if (x >= wx && x <= wx + width && y >= wy && y <= wy + height) {
+        return metaWindow;
+      }
+    }
+
+    // No window found at the pointer
+    return null;
   }
 
   /**

--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -2273,7 +2273,8 @@ export class WindowManager extends GObject.Object {
    */
   _focusWindowUnderPointer() {
     // Break the loop if the user has disabled the feature
-    if (!this.shouldFocusOnHover) return false;
+    // or if the window manager is disabled
+    if (!this.shouldFocusOnHover || this.disabled) return false;
 
     // We don't want to focus windows when the overview is visible
     if (Main.overview.visible) return true;

--- a/lib/prefs/settings.js
+++ b/lib/prefs/settings.js
@@ -84,6 +84,13 @@ export class SettingsPage extends PreferencesPage {
           settings,
           bind: "move-pointer-focus-enabled",
         }),
+        new SwitchRow({
+          title: _("Focus on Hover"),
+          subtitle: _("Window focus follows the pointer"),
+          experimental: true,
+          settings,
+          bind: "focus-on-hover-enabled",
+        }),
       ],
     });
 

--- a/po/es.po
+++ b/po/es.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Forge\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-31 19:54-0400\n"
+"POT-Creation-Date: 2024-12-17 16:51-0800\n"
 "PO-Revision-Date: 2021-09-18 16:25-0400\n"
 "Last-Translator: Jose Maranan <jmmaranan@gmail.com>\n"
 "Language-Team: \n"
@@ -14,7 +14,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lib/extension/indicator.js:47 lib/prefs/settings.js:91
+#: lib/extension/indicator.js:47 lib/prefs/settings.js:98
 msgid "Tiling"
 msgstr "Mosaico"
 
@@ -30,7 +30,7 @@ msgstr "Gestor de ventanas en mosaico"
 msgid "Gaps Hidden when Single"
 msgstr "Espacios ocultos cuando hay una sola ventana"
 
-#: lib/extension/indicator.js:78 lib/prefs/settings.js:100
+#: lib/extension/indicator.js:78 lib/prefs/settings.js:107
 msgid "Show Focus Hint Border"
 msgstr "Mostrar borde de sugerencia de enfoque"
 
@@ -38,7 +38,7 @@ msgstr "Mostrar borde de sugerencia de enfoque"
 msgid "Move Pointer with the Focus"
 msgstr "Mover el puntero con el enfoque"
 
-#: lib/extension/indicator.js:94 lib/extension/window.js:67
+#: lib/extension/indicator.js:94 lib/extension/window.js:70
 #: lib/prefs/settings.js:54 lib/prefs/settings.js:56
 msgid "Settings"
 msgstr "Configuración"
@@ -113,7 +113,9 @@ msgstr "Tecla Control"
 
 #: lib/prefs/keyboard.js:23
 msgid "Delete text to unset. Press Return key to accept. Focus out to ignore."
-msgstr "Borra el texto para desactivar. Pulsa la tecla Intro para aceptar. Sal del enfoque para ignorar."
+msgstr ""
+"Borra el texto para desactivar. Pulsa la tecla Intro para aceptar. Sal del "
+"enfoque para ignorar."
 
 #: lib/prefs/keyboard.js:24
 msgid "Resets"
@@ -133,11 +135,15 @@ msgstr "Opciones de tecla modificadora para mosaico con arrastrar y soltar"
 
 #: lib/prefs/keyboard.js:44
 msgid "Change the modifier for <b>tiling</b> windows via mouse/drag-drop"
-msgstr "Cambia la tecla modificadora para <b>organizar en mosaico</b> las ventanas mediante el ratón/arrastrar y soltar"
+msgstr ""
+"Cambia la tecla modificadora para <b>organizar en mosaico</b> las ventanas "
+"mediante el ratón/arrastrar y soltar"
 
 #: lib/prefs/keyboard.js:45
 msgid "Select <i>None</i> to <u>always tile immediately</u> by default"
-msgstr "Selecciona <i>Ninguna</i> para <u>organizar en mosaico inmediatamente</u> por defecto"
+msgstr ""
+"Selecciona <i>Ninguna</i> para <u>organizar en mosaico inmediatamente</u> "
+"por defecto"
 
 #: lib/prefs/keyboard.js:48
 msgid "Tile Modifier"
@@ -177,7 +183,8 @@ msgstr "Modo de mosaico apilado"
 
 #: lib/prefs/settings.js:62
 msgid "Stack windows on top of each other while still being tiled"
-msgstr "Apila las ventanas unas sobre otras mientras siguen organizadas en mosaico"
+msgstr ""
+"Apila las ventanas unas sobre otras mientras siguen organizadas en mosaico"
 
 #: lib/prefs/settings.js:68
 msgid "Tabbed Tiling Mode"
@@ -195,75 +202,85 @@ msgstr "Comportamiento"
 msgid "Move the pointer when focusing or swapping via keyboard"
 msgstr "Mover el puntero al enfocar o intercambiar mediante el teclado"
 
-#: lib/prefs/settings.js:94
+#: lib/prefs/settings.js:88
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Mostrar borde de sugerencia de enfoque"
+
+#: lib/prefs/settings.js:89
+#, fuzzy
+msgid "Window focus follows the pointer"
+msgstr "Mover el puntero con el enfoque"
+
+#: lib/prefs/settings.js:101
 msgid "Preview Hint Toggle"
 msgstr "Alternar vista previa de sugerencia"
 
-#: lib/prefs/settings.js:101
+#: lib/prefs/settings.js:108
 msgid "Display a colored border around the focused window"
 msgstr "Mostrar un borde de color alrededor de la ventana enfocada"
 
-#: lib/prefs/settings.js:106
+#: lib/prefs/settings.js:113
 msgid "Show Window Split Hint Border"
 msgstr "Mostrar borde de sugerencia de división de ventana"
 
-#: lib/prefs/settings.js:107
+#: lib/prefs/settings.js:114
 msgid "Show split direction border on focused window"
 msgstr "Mostrar borde de dirección de división en la ventana enfocada"
 
-#: lib/prefs/settings.js:112
+#: lib/prefs/settings.js:119
 msgid "Default Drag-and-Drop Center Layout"
 msgstr "Distribución central predeterminada de arrastrar y soltar"
 
-#: lib/prefs/settings.js:117
+#: lib/prefs/settings.js:124
 msgid "Swap"
 msgstr "Intercambiar"
 
-#: lib/prefs/settings.js:118
+#: lib/prefs/settings.js:125
 msgid "Tabbed"
 msgstr "En pestañas"
 
-#: lib/prefs/settings.js:119
+#: lib/prefs/settings.js:126
 msgid "Stacked"
 msgstr "Apilado"
 
-#: lib/prefs/settings.js:123
+#: lib/prefs/settings.js:130
 msgid "Auto Exit Tabbed Tiling Mode"
 msgstr "Salir automáticamente del modo de mosaico en pestañas"
 
-#: lib/prefs/settings.js:124
+#: lib/prefs/settings.js:131
 msgid "Exit tabbed tiling mode when only a single tab remains"
 msgstr "Salir del modo de mosaico en pestañas cuando solo queda una pestaña"
 
-#: lib/prefs/settings.js:129
+#: lib/prefs/settings.js:136
 msgid "Auto Split"
 msgstr "División automática"
 
-#: lib/prefs/settings.js:130
+#: lib/prefs/settings.js:137
 msgid "Quarter Tiling"
 msgstr "Mosaico en cuartos"
 
-#: lib/prefs/settings.js:136
+#: lib/prefs/settings.js:143
 msgid "Float Mode Always On Top"
 msgstr "Modo flotante siempre visible"
 
-#: lib/prefs/settings.js:137
+#: lib/prefs/settings.js:144
 msgid "Floating windows always above tiling windows"
 msgstr "Ventanas flotantes siempre encima de las ventanas en mosaico"
 
-#: lib/prefs/settings.js:143
+#: lib/prefs/settings.js:150
 msgid "Show Tiling Quick Settings"
 msgstr "Mostrar ajustes rápidos de mosaico"
 
-#: lib/prefs/settings.js:144
+#: lib/prefs/settings.js:151
 msgid "Toggle showing Forge on quick settings"
 msgstr "Alternar la visualización de Forge en los ajustes rápidos"
 
-#: lib/prefs/settings.js:154
+#: lib/prefs/settings.js:161
 msgid "Logger"
 msgstr "Registro"
 
-#: lib/prefs/settings.js:157
+#: lib/prefs/settings.js:164
 msgid "Logger Level"
 msgstr "Nivel de registro"
 
@@ -272,8 +289,8 @@ msgid ""
 "<b>CAUTION</b>: Enabling this setting can lead to bugs or cause the shell to "
 "crash"
 msgstr ""
-"<b>PRECAUCIÓN</b>: Activar esta configuración puede provocar errores o hacer que el entorno se "
-"bloquee"
+"<b>PRECAUCIÓN</b>: Activar esta configuración puede provocar errores o hacer "
+"que el entorno se bloquee"
 
 #: lib/prefs/widgets.js:222
 msgid "Reset"
@@ -292,8 +309,8 @@ msgid ""
 "Provide workspace indices to skip. E.g. 0,1. Empty text to disable. Enter to "
 "accept"
 msgstr ""
-"Indica los índices de espacios de trabajo a omitir. Ej.: 0,1. Dejar vacío para desactivar. Pulsa Intro para "
-"aceptar"
+"Indica los índices de espacios de trabajo a omitir. Ej.: 0,1. Dejar vacío "
+"para desactivar. Pulsa Intro para aceptar"
 
 #: lib/prefs/workspace.js:22
 msgid "Skip Workspace Tiling"

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Forge\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-31 19:54-0400\n"
+"POT-Creation-Date: 2024-12-17 16:51-0800\n"
 "PO-Revision-Date: 2023-02-28 17:16-0500\n"
 "Last-Translator: Wedone <wedoneofficiel@outlook.fr>\n"
 "Language-Team: French - Canada <wroy@proton.me>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1)\n"
 "X-Generator: Gtranslator 42.0\n"
 
-#: lib/extension/indicator.js:47 lib/prefs/settings.js:91
+#: lib/extension/indicator.js:47 lib/prefs/settings.js:98
 msgid "Tiling"
 msgstr "Mise en mosaîque"
 
@@ -33,7 +33,7 @@ msgstr "Gestion de Fenêtres en Mosaïque"
 msgid "Gaps Hidden when Single"
 msgstr "Marges masquées lorsqu'il y a une seule fenêtre"
 
-#: lib/extension/indicator.js:78 lib/prefs/settings.js:100
+#: lib/extension/indicator.js:78 lib/prefs/settings.js:107
 #, fuzzy
 msgid "Show Focus Hint Border"
 msgstr "Indice de focus flottant"
@@ -42,7 +42,7 @@ msgstr "Indice de focus flottant"
 msgid "Move Pointer with the Focus"
 msgstr "Déplacer le pointeur avec le Focus"
 
-#: lib/extension/indicator.js:94 lib/extension/window.js:67
+#: lib/extension/indicator.js:94 lib/extension/window.js:70
 #: lib/prefs/settings.js:54 lib/prefs/settings.js:56
 msgid "Settings"
 msgstr "Paramètres"
@@ -220,62 +220,72 @@ msgstr ""
 "Déplacer le pointeur lors de la mise au point ou de la permutation via le "
 "clavier"
 
-#: lib/prefs/settings.js:94
+#: lib/prefs/settings.js:88
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Indice de focus flottant"
+
+#: lib/prefs/settings.js:89
+#, fuzzy
+msgid "Window focus follows the pointer"
+msgstr "Déplacer le pointeur avec le Focus"
+
+#: lib/prefs/settings.js:101
 msgid "Preview Hint Toggle"
 msgstr "Basculer l'indice de prévisualisation"
 
-#: lib/prefs/settings.js:101
+#: lib/prefs/settings.js:108
 msgid "Display a colored border around the focused window"
 msgstr "Afficher une bordure colorée autour de la fenêtre focalisée"
 
-#: lib/prefs/settings.js:106
+#: lib/prefs/settings.js:113
 #, fuzzy
 msgid "Show Window Split Hint Border"
 msgstr "Indice de focus flottant"
 
-#: lib/prefs/settings.js:107
+#: lib/prefs/settings.js:114
 msgid "Show split direction border on focused window"
 msgstr "Afficher la bordure du sens de rotation sur la fenêtre focalisée"
 
-#: lib/prefs/settings.js:112
+#: lib/prefs/settings.js:119
 msgid "Default Drag-and-Drop Center Layout"
 msgstr "Disposition centrale par défaut du glisser-déposer"
 
-#: lib/prefs/settings.js:117
+#: lib/prefs/settings.js:124
 msgid "Swap"
 msgstr "Échange"
 
-#: lib/prefs/settings.js:118
+#: lib/prefs/settings.js:125
 msgid "Tabbed"
 msgstr "Onglets"
 
-#: lib/prefs/settings.js:119
+#: lib/prefs/settings.js:126
 msgid "Stacked"
 msgstr "Empilés"
 
-#: lib/prefs/settings.js:123
+#: lib/prefs/settings.js:130
 #, fuzzy
 msgid "Auto Exit Tabbed Tiling Mode"
 msgstr "Mode d'affichage par onglets"
 
-#: lib/prefs/settings.js:124
+#: lib/prefs/settings.js:131
 msgid "Exit tabbed tiling mode when only a single tab remains"
 msgstr ""
 
-#: lib/prefs/settings.js:129
+#: lib/prefs/settings.js:136
 msgid "Auto Split"
 msgstr "Séparation automatique"
 
-#: lib/prefs/settings.js:130
+#: lib/prefs/settings.js:137
 #, fuzzy
 msgid "Quarter Tiling"
 msgstr "Fractionnement automatique (Mosaïque en quart)"
 
-#: lib/prefs/settings.js:136
+#: lib/prefs/settings.js:143
 msgid "Float Mode Always On Top"
 msgstr "Mode flottant Toujours en haut"
 
-#: lib/prefs/settings.js:137
+#: lib/prefs/settings.js:144
 #, fuzzy
 msgid "Floating windows always above tiling windows"
 msgstr ""
@@ -283,20 +293,20 @@ msgstr ""
 "mosaïqueMode flottant toujours au-dessus (Les fenêtres flottantes toujours "
 "au-dessus des fenêtres en mosaïque)"
 
-#: lib/prefs/settings.js:143
+#: lib/prefs/settings.js:150
 msgid "Show Tiling Quick Settings"
 msgstr "Afficher les paramètres rapides de la mise en mosaïque"
 
-#: lib/prefs/settings.js:144
+#: lib/prefs/settings.js:151
 msgid "Toggle showing Forge on quick settings"
 msgstr "Basculer l'affichage de Forge sur les réglages rapides"
 
-#: lib/prefs/settings.js:154
+#: lib/prefs/settings.js:161
 #, fuzzy
 msgid "Logger"
 msgstr "Niveau de journalisation"
 
-#: lib/prefs/settings.js:157
+#: lib/prefs/settings.js:164
 msgid "Logger Level"
 msgstr "Niveau de journalisation"
 

--- a/po/it.po
+++ b/po/it.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Forge\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-31 19:54-0400\n"
+"POT-Creation-Date: 2024-12-17 16:51-0800\n"
 "PO-Revision-Date: 2024-09-15 20:16+0100\n"
 "Last-Translator: Albano Battistella <albanobattistella@gmail.com>\n"
 "Language-Team: Italian <albanobattistella@gmail.com>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1)\n"
 "X-Generator: Gtranslator 42.0\n"
 
-#: lib/extension/indicator.js:47 lib/prefs/settings.js:91
+#: lib/extension/indicator.js:47 lib/prefs/settings.js:98
 msgid "Tiling"
 msgstr "Affiancamento"
 
@@ -32,7 +32,7 @@ msgstr "Gestione delle finestre di affiancamento"
 msgid "Gaps Hidden when Single"
 msgstr "Margini nascosti quando c'è una sola finestra"
 
-#: lib/extension/indicator.js:78 lib/prefs/settings.js:100
+#: lib/extension/indicator.js:78 lib/prefs/settings.js:107
 msgid "Show Focus Hint Border"
 msgstr "Mostra suggerimento del bordo di messa a fuoco"
 
@@ -40,7 +40,7 @@ msgstr "Mostra suggerimento del bordo di messa a fuoco"
 msgid "Move Pointer with the Focus"
 msgstr "Sposta il puntatore con il focus"
 
-#: lib/extension/indicator.js:94 lib/extension/window.js:67
+#: lib/extension/indicator.js:94 lib/extension/window.js:70
 #: lib/prefs/settings.js:54 lib/prefs/settings.js:56
 msgid "Settings"
 msgstr "Impostazioni"
@@ -210,76 +210,87 @@ msgid "Move the pointer when focusing or swapping via keyboard"
 msgstr ""
 "Muovi il puntatore durante la messa a fuoco o lo scambio tramite tastiera"
 
-#: lib/prefs/settings.js:94
+#: lib/prefs/settings.js:88
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Mostra suggerimento del bordo di messa a fuoco"
+
+#: lib/prefs/settings.js:89
+#, fuzzy
+msgid "Window focus follows the pointer"
+msgstr "Sposta il puntatore con il focus"
+
+#: lib/prefs/settings.js:101
 msgid "Preview Hint Toggle"
 msgstr "Attiva/disattiva l'indice di anteprima"
 
-#: lib/prefs/settings.js:101
+#: lib/prefs/settings.js:108
 msgid "Display a colored border around the focused window"
 msgstr "Visualizza un bordo colorato attorno alla finestra focalizzata"
 
-#: lib/prefs/settings.js:106
+#: lib/prefs/settings.js:113
 msgid "Show Window Split Hint Border"
 msgstr "Mostra suggerimento finestra del bordo di messa a fuoco"
 
-#: lib/prefs/settings.js:107
+#: lib/prefs/settings.js:114
 msgid "Show split direction border on focused window"
 msgstr ""
 "Mostra il bordo della direzione di divisione sulla finestra focalizzata"
 
-#: lib/prefs/settings.js:112
+#: lib/prefs/settings.js:119
 msgid "Default Drag-and-Drop Center Layout"
 msgstr "Layout di trascinamento della selezione centrale predefinito"
 
-#: lib/prefs/settings.js:117
+#: lib/prefs/settings.js:124
 msgid "Swap"
 msgstr ""
 
-#: lib/prefs/settings.js:118
+#: lib/prefs/settings.js:125
 msgid "Tabbed"
 msgstr "Schede"
 
-#: lib/prefs/settings.js:119
+#: lib/prefs/settings.js:126
 msgid "Stacked"
 msgstr "Impilate"
 
-#: lib/prefs/settings.js:123
+#: lib/prefs/settings.js:130
 msgid "Auto Exit Tabbed Tiling Mode"
 msgstr "Uscita automatica dalla modalità di affiancamento a schede"
 
-#: lib/prefs/settings.js:124
+#: lib/prefs/settings.js:131
 msgid "Exit tabbed tiling mode when only a single tab remains"
-msgstr "Esci dalla modalità di affiancamento a schede quando rimane solo una scheda"
+msgstr ""
+"Esci dalla modalità di affiancamento a schede quando rimane solo una scheda"
 
-#: lib/prefs/settings.js:129
+#: lib/prefs/settings.js:136
 msgid "Auto Split"
 msgstr "Divisione automatica"
 
-#: lib/prefs/settings.js:130
+#: lib/prefs/settings.js:137
 msgid "Quarter Tiling"
 msgstr "Affiancamento a quarto"
 
-#: lib/prefs/settings.js:136
+#: lib/prefs/settings.js:143
 msgid "Float Mode Always On Top"
 msgstr "Modalità flottante sempre in primo piano"
 
-#: lib/prefs/settings.js:137
+#: lib/prefs/settings.js:144
 msgid "Floating windows always above tiling windows"
 msgstr "Finestre flottanti sempre sopra le finestre affiancate"
 
-#: lib/prefs/settings.js:143
+#: lib/prefs/settings.js:150
 msgid "Show Tiling Quick Settings"
 msgstr "Mostra le impostazioni rapide di affiancamento"
 
-#: lib/prefs/settings.js:144
+#: lib/prefs/settings.js:151
 msgid "Toggle showing Forge on quick settings"
 msgstr "Attiva la visualizzazione di Forge nelle impostazioni rapide"
 
-#: lib/prefs/settings.js:154
+#: lib/prefs/settings.js:161
 msgid "Logger"
 msgstr "Log"
 
-#: lib/prefs/settings.js:157
+#: lib/prefs/settings.js:164
 msgid "Logger Level"
 msgstr "Livello Log"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Forge\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-31 19:54-0400\n"
+"POT-Creation-Date: 2024-12-17 16:51-0800\n"
 "PO-Revision-Date: 2021-12-29 19:04+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: \n"
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0\n"
 
-#: lib/extension/indicator.js:47 lib/prefs/settings.js:91
+#: lib/extension/indicator.js:47 lib/prefs/settings.js:98
 msgid "Tiling"
 msgstr ""
 
@@ -30,7 +30,7 @@ msgstr ""
 msgid "Gaps Hidden when Single"
 msgstr "Ruimtes verbergen bij één geopend venster"
 
-#: lib/extension/indicator.js:78 lib/prefs/settings.js:100
+#: lib/extension/indicator.js:78 lib/prefs/settings.js:107
 #, fuzzy
 msgid "Show Focus Hint Border"
 msgstr "Focushint bij zwevende vensters"
@@ -39,7 +39,7 @@ msgstr "Focushint bij zwevende vensters"
 msgid "Move Pointer with the Focus"
 msgstr ""
 
-#: lib/extension/indicator.js:94 lib/extension/window.js:67
+#: lib/extension/indicator.js:94 lib/extension/window.js:70
 #: lib/prefs/settings.js:54 lib/prefs/settings.js:56
 msgid "Settings"
 msgstr "Voorkeuren"
@@ -205,77 +205,86 @@ msgstr ""
 msgid "Move the pointer when focusing or swapping via keyboard"
 msgstr ""
 
-#: lib/prefs/settings.js:94
-msgid "Preview Hint Toggle"
+#: lib/prefs/settings.js:88
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Focushint bij zwevende vensters"
+
+#: lib/prefs/settings.js:89
+msgid "Window focus follows the pointer"
 msgstr ""
 
 #: lib/prefs/settings.js:101
+msgid "Preview Hint Toggle"
+msgstr ""
+
+#: lib/prefs/settings.js:108
 msgid "Display a colored border around the focused window"
 msgstr ""
 
-#: lib/prefs/settings.js:106
+#: lib/prefs/settings.js:113
 #, fuzzy
 msgid "Show Window Split Hint Border"
 msgstr "Focushint bij zwevende vensters"
 
-#: lib/prefs/settings.js:107
+#: lib/prefs/settings.js:114
 msgid "Show split direction border on focused window"
 msgstr ""
 
-#: lib/prefs/settings.js:112
+#: lib/prefs/settings.js:119
 msgid "Default Drag-and-Drop Center Layout"
 msgstr "Standaardindeling: gecentreerd slepen-en-neerzetten"
 
-#: lib/prefs/settings.js:117
+#: lib/prefs/settings.js:124
 msgid "Swap"
 msgstr ""
 
-#: lib/prefs/settings.js:118
+#: lib/prefs/settings.js:125
 msgid "Tabbed"
 msgstr "Tabbladen"
 
-#: lib/prefs/settings.js:119
+#: lib/prefs/settings.js:126
 msgid "Stacked"
 msgstr "Gestapeld"
 
-#: lib/prefs/settings.js:123
+#: lib/prefs/settings.js:130
 msgid "Auto Exit Tabbed Tiling Mode"
 msgstr ""
 
-#: lib/prefs/settings.js:124
+#: lib/prefs/settings.js:131
 msgid "Exit tabbed tiling mode when only a single tab remains"
 msgstr ""
 
-#: lib/prefs/settings.js:129
+#: lib/prefs/settings.js:136
 msgid "Auto Split"
 msgstr ""
 
-#: lib/prefs/settings.js:130
+#: lib/prefs/settings.js:137
 msgid "Quarter Tiling"
 msgstr ""
 
-#: lib/prefs/settings.js:136
+#: lib/prefs/settings.js:143
 msgid "Float Mode Always On Top"
 msgstr ""
 
-#: lib/prefs/settings.js:137
+#: lib/prefs/settings.js:144
 msgid "Floating windows always above tiling windows"
 msgstr ""
 
-#: lib/prefs/settings.js:143
+#: lib/prefs/settings.js:150
 msgid "Show Tiling Quick Settings"
 msgstr ""
 
-#: lib/prefs/settings.js:144
+#: lib/prefs/settings.js:151
 msgid "Toggle showing Forge on quick settings"
 msgstr ""
 
-#: lib/prefs/settings.js:154
+#: lib/prefs/settings.js:161
 #, fuzzy
 msgid "Logger"
 msgstr "Logniveau"
 
-#: lib/prefs/settings.js:157
+#: lib/prefs/settings.js:164
 msgid "Logger Level"
 msgstr "Logniveau"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Forge\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-31 19:54-0400\n"
+"POT-Creation-Date: 2024-12-17 16:51-0800\n"
 "PO-Revision-Date: 2021-09-18 16:25-0400\n"
 "Last-Translator: Juarez Rudsatz <juarezr@gmail.com>\n"
 "Language-Team: \n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lib/extension/indicator.js:47 lib/prefs/settings.js:91
+#: lib/extension/indicator.js:47 lib/prefs/settings.js:98
 msgid "Tiling"
 msgstr "Emparelhamento"
 
@@ -28,7 +28,7 @@ msgstr "Gerenciamento de Janelas Emparelhadas"
 msgid "Gaps Hidden when Single"
 msgstr "Espaçamento Omitido quando Sozinho"
 
-#: lib/extension/indicator.js:78 lib/prefs/settings.js:100
+#: lib/extension/indicator.js:78 lib/prefs/settings.js:107
 #, fuzzy
 msgid "Show Focus Hint Border"
 msgstr "Sinalizador de Foco Flutuante"
@@ -37,7 +37,7 @@ msgstr "Sinalizador de Foco Flutuante"
 msgid "Move Pointer with the Focus"
 msgstr "Mover o Ponteiro com o Foco"
 
-#: lib/extension/indicator.js:94 lib/extension/window.js:67
+#: lib/extension/indicator.js:94 lib/extension/window.js:70
 #: lib/prefs/settings.js:54 lib/prefs/settings.js:56
 msgid "Settings"
 msgstr "Configurações"
@@ -206,82 +206,92 @@ msgstr "Comportamento"
 msgid "Move the pointer when focusing or swapping via keyboard"
 msgstr "Mover o Ponteiro ao focar ou transpor janelas via teclado"
 
-#: lib/prefs/settings.js:94
+#: lib/prefs/settings.js:88
+#, fuzzy
+msgid "Focus on Hover"
+msgstr "Sinalizador de Foco Flutuante"
+
+#: lib/prefs/settings.js:89
+#, fuzzy
+msgid "Window focus follows the pointer"
+msgstr "Mover o Ponteiro com o Foco"
+
+#: lib/prefs/settings.js:101
 msgid "Preview Hint Toggle"
 msgstr "Habilitar Ver Dica"
 
-#: lib/prefs/settings.js:101
+#: lib/prefs/settings.js:108
 msgid "Display a colored border around the focused window"
 msgstr "Exibir uma borda colorida ao redor da janela com foco"
 
-#: lib/prefs/settings.js:106
+#: lib/prefs/settings.js:113
 #, fuzzy
 msgid "Show Window Split Hint Border"
 msgstr "Sinalizador de Foco Flutuante"
 
-#: lib/prefs/settings.js:107
+#: lib/prefs/settings.js:114
 msgid "Show split direction border on focused window"
 msgstr "Exibir a borda de divisão na janela com foco"
 
-#: lib/prefs/settings.js:112
+#: lib/prefs/settings.js:119
 msgid "Default Drag-and-Drop Center Layout"
 msgstr "Arranjo de Arrastar/Soltar Padrão"
 
-#: lib/prefs/settings.js:117
+#: lib/prefs/settings.js:124
 msgid "Swap"
 msgstr ""
 
-#: lib/prefs/settings.js:118
+#: lib/prefs/settings.js:125
 msgid "Tabbed"
 msgstr "Em Abas"
 
-#: lib/prefs/settings.js:119
+#: lib/prefs/settings.js:126
 msgid "Stacked"
 msgstr "Empilhado"
 
-#: lib/prefs/settings.js:123
+#: lib/prefs/settings.js:130
 #, fuzzy
 msgid "Auto Exit Tabbed Tiling Mode"
 msgstr "Modo em Abas"
 
-#: lib/prefs/settings.js:124
+#: lib/prefs/settings.js:131
 msgid "Exit tabbed tiling mode when only a single tab remains"
 msgstr ""
 
-#: lib/prefs/settings.js:129
+#: lib/prefs/settings.js:136
 msgid "Auto Split"
 msgstr "Dividir automaticamente"
 
-#: lib/prefs/settings.js:130
+#: lib/prefs/settings.js:137
 #, fuzzy
 msgid "Quarter Tiling"
 msgstr "Divisão Automática (Metade)"
 
-#: lib/prefs/settings.js:136
+#: lib/prefs/settings.js:143
 msgid "Float Mode Always On Top"
 msgstr "Modo Flutuante sempre no topo"
 
-#: lib/prefs/settings.js:137
+#: lib/prefs/settings.js:144
 #, fuzzy
 msgid "Floating windows always above tiling windows"
 msgstr ""
 "Modo Flutuante Sempre no Topo (Janelas flutuantes sempre acima de janelas "
 "emparelhadas)"
 
-#: lib/prefs/settings.js:143
+#: lib/prefs/settings.js:150
 msgid "Show Tiling Quick Settings"
 msgstr "Exibir configurações rápidas"
 
-#: lib/prefs/settings.js:144
+#: lib/prefs/settings.js:151
 msgid "Toggle showing Forge on quick settings"
 msgstr "Habilitar a exibição do Forge nas configurações rápidas"
 
-#: lib/prefs/settings.js:154
+#: lib/prefs/settings.js:161
 #, fuzzy
 msgid "Logger"
 msgstr "Nivel de Log"
 
-#: lib/prefs/settings.js:157
+#: lib/prefs/settings.js:164
 msgid "Logger Level"
 msgstr "Nivel de Log"
 

--- a/schemas/org.gnome.shell.extensions.forge.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.forge.gschema.xml
@@ -123,6 +123,10 @@
             <default>false</default>
             <summary>Move the pointer when focusing or swapping via kbd</summary>
         </key>
+        <key type="b" name="focus-on-hover-enabled">
+            <default>false</default>
+            <summary>Focus switches to the window under the pointer.</summary>
+        </key>
         <key type="b" name="float-always-on-top-enabled">
             <default>true</default>
             <summary>Floating windows toggle always-on-top</summary>


### PR DESCRIPTION
This could have been simply done using gnome-tweaks, but it can be buggy at times (see #258). This custom implementation doesn't run into the issues gnome-tweaks does, but this comes at the cost of efficiency: it gets the position of the pointer every 16 milliseconds and updates the focus. I couldn't find a better way of implementing this.