### PR TITLE
feat: add a key binding to close windows

### DIFF
--- a/lib/extension/keybindings.js
+++ b/lib/extension/keybindings.js
@@ -175,6 +175,10 @@ export class Keybindings extends GObject.Object {
 
   buildBindingDefinitions() {
     this._bindings = {
+      "window-close": () => {
+        let action = { name: "Close" };
+        this.extWm.command(action);
+      },
       "window-toggle-float": () => {
         let actions = [
           {

--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -434,6 +434,12 @@ export class WindowManager extends GObject.Object {
     let currentLayout;
 
     switch (action.name) {
+      case "Close":
+        if (focusWindow) {
+          focusWindow.delete(global.display.get_current_time());
+        }
+
+        break;
       case "FloatNonPersistentToggle":
       case "FloatToggle":
       case "FloatClassToggle":

--- a/schemas/org.gnome.shell.extensions.forge.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.forge.gschema.xml
@@ -197,6 +197,11 @@
             <summary>Swap window left</summary>
         </key>
 
+        <key type="as" name="window-close">
+            <default><![CDATA[['<Super>q']]]></default>
+            <summary>Close window</summary>
+        </key>
+
         <key type="as" name="window-swap-down">
             <default><![CDATA[['<Ctrl><Super>j']]]></default>
             <summary>Swap window down</summary>


### PR DESCRIPTION
Pressing Alt+F4 isn't always the most ergonomic option, so adding a key bind specifically for closing windows makes sense.