### PR TITLE
Remove potentially dangling pointer timer

### DIFF
--- a/lib/extension/window.js
+++ b/lib/extension/window.js
@@ -86,6 +86,10 @@ export class WindowManager extends GObject.Object {
   }
 
   pointerLoopInit() {
+    if (this._pointerFocusTimeoutId) {
+      GLib.Source.remove(this._pointerFocusTimeoutId);
+    }
+
     this._pointerFocusTimeoutId = GLib.timeout_add(
       GLib.PRIORITY_DEFAULT,
       16,


### PR DESCRIPTION
As mentioned in this review: https://extensions.gnome.org/review/63403