### PR TITLE
Update summary for `resize-amount`

### DIFF
--- a/schemas/org.gnome.shell.extensions.forge.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.forge.gschema.xml
@@ -37,7 +37,7 @@
         <key type="u" name="resize-amount">
             <default>15</default>
             <summary>
-                The size of the gap between windows in the workarea
+                The window resize increment/decrement in pixels
             </summary>
         </key>
 


### PR DESCRIPTION
I noticed that the summary for this field was the same as `window-gap-size`. I added one, trying to maintain the same format.