### PR TITLE
Fix workspace index and update monitor IDs after deletion

### DIFF
--- a/lib/extension/tree.js
+++ b/lib/extension/tree.js
@@ -363,7 +363,7 @@ export class Node extends GObject.Object {
       // Since contains() tries to find node on all descendants,
       // detach only from the immediate parent
       let parentNode = node.parentNode;
-      refNode = parentNode.childNodes[node.index]
+      refNode = parentNode.childNodes[node.index];
 
       parentNode.childNodes.splice(node.index, 1);
       refNode.parentNode = null;
@@ -1319,8 +1319,7 @@ export class Tree extends Node {
           let metaWin = w.nodeValue;
           try {
             this.extWm.move(metaWin, w.renderRect);
-          } catch (e) {
-          }
+          } catch (e) {}
         } else {
           Logger.debug(`ignoring apply for ${w.renderRect.width}x${w.renderRect.height}`);
         }
@@ -1431,17 +1430,19 @@ export class Tree extends Node {
       }
 
       // Skip windows whose actors were destroyed mid-render
-      tiledChildren.filter((c) => c.isNodeValid()).forEach((child, index) => {
-        // A monitor can contain a window or container child
-        if (node.layout === LAYOUT_TYPES.HSPLIT || node.layout === LAYOUT_TYPES.VSPLIT) {
-          this.processSplit(node, child, params, index);
-        } else if (node.layout === LAYOUT_TYPES.STACKED) {
-          this.processStacked(node, child, params, index);
-        } else if (node.layout === LAYOUT_TYPES.TABBED) {
-          this.processTabbed(node, child, params, index);
-        }
-        this.processNode(child);
-      });
+      tiledChildren
+        .filter((c) => c.isNodeValid())
+        .forEach((child, index) => {
+          // A monitor can contain a window or container child
+          if (node.layout === LAYOUT_TYPES.HSPLIT || node.layout === LAYOUT_TYPES.VSPLIT) {
+            this.processSplit(node, child, params, index);
+          } else if (node.layout === LAYOUT_TYPES.STACKED) {
+            this.processStacked(node, child, params, index);
+          } else if (node.layout === LAYOUT_TYPES.TABBED) {
+            this.processTabbed(node, child, params, index);
+          }
+          this.processNode(child);
+        });
     }
 
     if (node.isWindow()) {
@@ -1582,8 +1583,7 @@ export class Tree extends Node {
             if (child.actor?.border) {
               borderWidth = child.actor.border.get_theme_node().get_border_width(St.Side.TOP);
             }
-          } catch (e) {
-          }
+          } catch (e) {}
 
           // Make adjustments to the gaps
           let adjust = 4 * Utils.dpi();
@@ -1608,8 +1608,7 @@ export class Tree extends Node {
             if (child.tab && !decoration.contains(child.tab)) {
               try {
                 decoration.add_child(child.tab);
-              } catch (e) {
-              }
+              } catch (e) {}
             }
           }
 

--- a/lib/extension/tree.js
+++ b/lib/extension/tree.js
@@ -363,7 +363,9 @@ export class Node extends GObject.Object {
       // Since contains() tries to find node on all descendants,
       // detach only from the immediate parent
       let parentNode = node.parentNode;
-      refNode = parentNode.childNodes.splice(node.index, 1);
+      refNode = parentNode.childNodes[node.index]
+
+      parentNode.childNodes.splice(node.index, 1);
       refNode.parentNode = null;
     }
     if (!refNode) {
@@ -709,6 +711,28 @@ export class Tree extends Node {
       global.window_group.remove_child(existingWsNode.actorBin);
 
     this.removeChild(existingWsNode);
+
+    let workspaces = this.nodeWorkpaces;
+    workspaces.forEach((wsNode) => {
+      // Extract the current integer index from "ws{n}"
+      let currentIndex = parseInt(wsNode.nodeValue.replace("ws", ""));
+
+      // If the workspace was after the deleted one, shift it down
+      if (currentIndex > wsIndex) {
+        let newIndex = currentIndex - 1;
+        wsNode._data = `ws${newIndex}`;
+
+        // Also update the IDs of the Monitor children
+        wsNode.childNodes.forEach((child) => {
+          if (child.nodeType === NODE_TYPES.MONITOR) {
+            // Monitor node values look like "mo{m}ws{n}"
+            let parts = child.nodeValue.split("ws");
+            child._data = `${parts[0]}ws${newIndex}`;
+          }
+        });
+      }
+    });
+
     return true;
   }
 

--- a/lib/extension/tree.js
+++ b/lib/extension/tree.js
@@ -363,7 +363,7 @@ export class Node extends GObject.Object {
       // Since contains() tries to find node on all descendants,
       // detach only from the immediate parent
       let parentNode = node.parentNode;
-      refNode = parentNode.childNodes[node.index]
+      refNode = parentNode.childNodes[node.index];
 
       parentNode.childNodes.splice(node.index, 1);
       refNode.parentNode = null;


### PR DESCRIPTION
This PR addresses the layout breaking when a workspace is dynamically deleted by GNOME (#470), and fixes a reference bug related to node detachment.

Fixes #470

## Details
### workspace index desync on deletion
When an empty workspace is closed, GNOME dynamically deletes it and shifts the indices of the remaining workspaces down.
Previously, the extension's internal tree removed the target workspace node but left the subsequent `ws{n}` nodes unchanged. This desync caused the window manager to mistakenly group windows from different workspaces into the same container, breaking their fullscreen state.

Fix: Added logic in removeWorkspace to iterate through the remaining workspaces and decrement the IDs (e.g., `ws2` -> `ws1`) of any workspaces and child monitors that come after the deleted index.

### dangling parentNode reference in `removeChild`
While investigating, I noticed a bug in `Node.removeChild`.
The code was assigning the result of `splice()` to `refNode`, and then calling `refNode.parentNode = null`.
Because splice() returns an array, this was just setting a useless property on the array object, leaving the actual node's parent reference completely intact.

Fix: Extracted the actual node via its index before calling splice(), ensuring the tree reference is properly severed.

## Notes
Full disclosure: I personally encountered the issue #470 and wanted to fix, but I don't usually write JavaScript, so I used an AI assistant to help trace the root cause of the tree desync and draft this fix.
I've tested it locally and it resolves the issue described in #470, but I would really appreciate it if an experienced extension could give this a close review.