### PR TITLE
Add GNOME Shell 50.1 compatibility metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ patchcss:
 
 metadata:
 	echo "export const developers = Object.entries([" > lib/prefs/metadata.js
-	git shortlog -sne || echo "" >> lib/prefs/metadata.js
-	awk -i inplace '!/dependabot|noreply/' lib/prefs/metadata.js
+	git shortlog -sne >> lib/prefs/metadata.js || echo "" >> lib/prefs/metadata.js
+	awk '!/dependabot|noreply/' lib/prefs/metadata.js > lib/prefs/metadata.js.tmp && mv lib/prefs/metadata.js.tmp lib/prefs/metadata.js
 	sed -i 's/^[[:space:]]*[0-9]*[[:space:]]*\(.*\) <\(.*\)>/  {name:"\1", email:"\2"},/g' lib/prefs/metadata.js
 	echo "].reduce((acc, x) => ({ ...acc, [x.email]: acc[x.email] ?? x.name }), {})).map(([email, name]) => name + ' <' + email + '>')" >> lib/prefs/metadata.js
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Forge is a GNOME Shell extension that provides tiling/window management **_AND_*
 
 ## Features
 
-- Works on GNOME 3.36+ (feature-freeze) and 40+. X11 and Wayland
+- Works on GNOME 45 through 50.1. X11 and Wayland
 - Tree-based tiling with vertical and horizontal split containers similar to i3-wm and sway-wm
 - Vim-like keybindings for navigation/swapping windows/moving windows in the containers
 - Drag and drop tiling

--- a/lib/extension/tree.js
+++ b/lib/extension/tree.js
@@ -1295,8 +1295,7 @@ export class Tree extends Node {
           let metaWin = w.nodeValue;
           try {
             this.extWm.move(metaWin, w.renderRect);
-          } catch (e) {
-          }
+          } catch (e) {}
         } else {
           Logger.debug(`ignoring apply for ${w.renderRect.width}x${w.renderRect.height}`);
         }
@@ -1407,17 +1406,19 @@ export class Tree extends Node {
       }
 
       // Skip windows whose actors were destroyed mid-render
-      tiledChildren.filter((c) => c.isNodeValid()).forEach((child, index) => {
-        // A monitor can contain a window or container child
-        if (node.layout === LAYOUT_TYPES.HSPLIT || node.layout === LAYOUT_TYPES.VSPLIT) {
-          this.processSplit(node, child, params, index);
-        } else if (node.layout === LAYOUT_TYPES.STACKED) {
-          this.processStacked(node, child, params, index);
-        } else if (node.layout === LAYOUT_TYPES.TABBED) {
-          this.processTabbed(node, child, params, index);
-        }
-        this.processNode(child);
-      });
+      tiledChildren
+        .filter((c) => c.isNodeValid())
+        .forEach((child, index) => {
+          // A monitor can contain a window or container child
+          if (node.layout === LAYOUT_TYPES.HSPLIT || node.layout === LAYOUT_TYPES.VSPLIT) {
+            this.processSplit(node, child, params, index);
+          } else if (node.layout === LAYOUT_TYPES.STACKED) {
+            this.processStacked(node, child, params, index);
+          } else if (node.layout === LAYOUT_TYPES.TABBED) {
+            this.processTabbed(node, child, params, index);
+          }
+          this.processNode(child);
+        });
     }
 
     if (node.isWindow()) {
@@ -1558,8 +1559,7 @@ export class Tree extends Node {
             if (child.actor?.border) {
               borderWidth = child.actor.border.get_theme_node().get_border_width(St.Side.TOP);
             }
-          } catch (e) {
-          }
+          } catch (e) {}
 
           // Make adjustments to the gaps
           let adjust = 4 * Utils.dpi();
@@ -1584,8 +1584,7 @@ export class Tree extends Node {
             if (child.tab && !decoration.contains(child.tab)) {
               try {
                 decoration.add_child(child.tab);
-              } catch (e) {
-              }
+              } catch (e) {}
             }
           }
 

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "gettext-domain": "forge",
   "uuid": "forge@jmmaranan.com",
   "settings-schema": "org.gnome.shell.extensions.forge",
-  "shell-version": ["45", "46", "47", "48", "49", "50"],
+  "shell-version": ["45", "46", "47", "48", "49", "50", "50.1"],
   "session-modes": ["user", "unlock-dialog"],
   "url": "https://github.com/forge-ext/forge"
 }


### PR DESCRIPTION
Adds Shell 50.1 to extension metadata and updates README support statement so downstream packaging/review reflects current compatibility target.

Extension Manager currently flags Forge unsupported on 50.1 because the published EGO shell-version map stops at 49. This patch aligns metadata with current compatibility expectations and should be included in the next reviewed upload.